### PR TITLE
Simplify artifact zipping in CI workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,14 +47,12 @@ jobs:
       - name: Zip Linux artifact
         run: |
           mkdir -p artifacts
-          cd listenarr.api/publish/linux-x64
-          zip -r ../../../../artifacts/listenarr-api-linux-x64.zip .
+          zip -r artifacts/listenarr-api-linux-x64.zip listenarr.api/publish/linux-x64/
 
       - name: Zip Windows artifact
         run: |
           mkdir -p artifacts
-          cd listenarr.api/publish/win-x64
-          zip -r ../../../../artifacts/listenarr-api-win-x64.zip .
+          zip -r artifacts/listenarr-api-win-x64.zip listenarr.api/publish/win-x64/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,9 @@ jobs:
       - name: Zip artifacts
         run: |
           mkdir -p artifacts
-          cd listenarr.api/publish/linux-x64 && zip -r ../../artifacts/listenarr-api-linux-x64.zip .
-          cd listenarr.api/publish/win-x64 && zip -r ../../artifacts/listenarr-api-win-x64.zip .
-          cd listenarr.api/publish/osx-x64 && zip -r ../../artifacts/listenarr-api-osx-x64.zip .
+          zip -r artifacts/listenarr-api-linux-x64.zip listenarr.api/publish/linux-x64/
+          zip -r artifacts/listenarr-api-win-x64.zip listenarr.api/publish/win-x64/
+          zip -r artifacts/listenarr-api-osx-x64.zip listenarr.api/publish/osx-x64/
 
       - name: Upload release artifacts
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This pull request updates the artifact packaging steps in both the nightly and release GitHub Actions workflows. The main change is simplifying how the zip files are created for each platform by removing unnecessary directory changes and using direct paths, which makes the workflow easier to read and maintain.

**Workflow improvements:**

* [`.github/workflows/nightly.yml`](diffhunk://#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6L50-R55): Updated the artifact zipping commands for Linux and Windows to use direct paths instead of changing directories, streamlining the process and reducing complexity.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L52-R54): Refactored the zipping commands for Linux, Windows, and OSX artifacts to use direct paths, eliminating multiple `cd` commands and making the steps more straightforward.Replaces directory changes and relative paths with direct zip commands in nightly and release GitHub Actions workflows, improving readability and reliability of artifact creation steps.