### PR TITLE
Bump version to 1.0.7

### DIFF
--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
This PR bumps the application version to 1.0.7.
The change was produced automatically by the CI nightly workflow.