### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
     <AssemblyVersion>0.1.0</AssemblyVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
This PR bumps the application version to 0.1.2.
The change was produced automatically by the CI nightly workflow.