### PR TITLE
Bump version to 0.1.8

### DIFF
--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -4,8 +4,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     
-    <Version>0.1.7</Version>
-    <AssemblyVersion>0.1.7</AssemblyVersion>
+    <Version>0.1.8</Version>
+    <AssemblyVersion>0.1.8</AssemblyVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
@@ -85,7 +85,7 @@
     <Copy SourceFiles="@(FrontendDistFilesForNestedPublish)" DestinationFiles="@(FrontendDistFilesForNestedPublish-&gt;'$(MSBuildProjectDirectory)\\publish\\publish\\wwwroot\\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="false" />
   </Target>
 
-  <!-- Exclude config.json from publish since it's now generated at runtime -->
+  
   <ItemGroup>
     <Content Remove="config\config.json" />
     <None Remove="config\config.json" />


### PR DESCRIPTION
This PR bumps the application version to 0.1.8.
The change was produced automatically by the CI nightly workflow.