### PR TITLE
Refactor PR body handling in workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -187,32 +187,23 @@ jobs:
           state: all
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Parse PR body
-        id: parse-body
+      - name: Get PR body
+        id: pr_body
         run: |
-          body="${{ steps.findPr.outputs.body }}"
-          if [[ ${#body} -gt 1870 ]] ; then
-            body=${body:0:1870}
-            body="${body}...and much more.
-
-            Read full changelog: https://github.com/therobbiedavis/Listenarr/pull/${{ steps.findPr.outputs.pr }}"
-          fi
-
-          body=${body//\'/}
-          body=${body//'%'/'%25'}
-          body=${body//$'\n'/'%0A'}
-          body=${body//$'\r'/'%0D'}
-          body=${body//$'`'/'%60'}
-          body=${body//$'>'/'%3E'}
-          echo $body
-          echo "BODY=$body" >> $GITHUB_OUTPUT
+          PR_BODY=$(gh api repos/${{ github.repository }}/pulls/${{ steps.create_pr.outputs['pull-request-number'] }} --jq .body)
+          FULL_BODY=$(printf '%s\n\n---\n\nAutomated nightly build.\n\nVersion: ${{ steps.resolve-version.outputs.VERSION }}\nCommit: ${{ github.sha }}' "$PR_BODY")
+          echo "FULL_BODY<<EOF" >> $GITHUB_OUTPUT
+          echo "$FULL_BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Pre-Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.resolve-version.outputs.VERSION }}
           name: Nightly ${{ steps.resolve-version.outputs.VERSION }}
-          body: ${{ steps.findPr.outputs.body }}
+          body: ${{ steps.pr_body.outputs.FULL_BODY }}
           prerelease: true
           files: artifacts/*.zip
         env:
@@ -247,7 +238,7 @@ jobs:
         with:
             severity: info
             description: v${{steps.resolve-version.outputs.VERSION}} - ${{ steps.findPr.outputs.title }}
-            details: '${{ steps.findPr.outputs.body }}'
+            details: '${{ steps.pr_body.outputs.FULL_BODY }}'
             text: A new nightly build has been released for docker.
             webhookUrl: ${{ secrets.DISCORD_DOCKER_UPDATE_URL }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,25 +137,16 @@ jobs:
           state: all
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Parse PR body
-        id: parse-body
+      - name: Get PR body
+        id: pr_body
         run: |
-          body="${{ steps.findPr.outputs.body }}"
-          if [[ ${#body} -gt 1870 ]] ; then
-            body=${body:0:1870}
-            body="${body}...and much more.
-
-            Read full changelog: https://github.com/therobbiedavis/Listenarr/pull/${{ steps.findPr.outputs.pr }}"
-          fi
-
-          body=${body//\'/}
-          body=${body//'%'/'%25'}
-          body=${body//$'\n'/'%0A'}
-          body=${body//$'\r'/'%0D'}
-          body=${body//$'`'/'%60'}
-          body=${body//$'>'/'%3E'}
-          echo $body
-          echo "BODY=$body" >> $GITHUB_OUTPUT
+          PR_BODY=$(gh api repos/${{ github.repository }}/pulls/${{ steps.create_pr.outputs['pull-request-number'] }} --jq .body)
+          FULL_BODY=$(printf '%s\n\n---\n\nAutomated nightly build.\n\nVersion: ${{ steps.resolve-version.outputs.VERSION }}\nCommit: ${{ github.sha }}' "$PR_BODY")
+          echo "FULL_BODY<<EOF" >> $GITHUB_OUTPUT
+          echo "$FULL_BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build solution
         run: dotnet build listenarr.sln -c Release --no-restore


### PR DESCRIPTION
This pull request updates the nightly and release GitHub Actions workflows to improve how the pull request body is retrieved and formatted for use in releases and notifications. The main change is replacing the manual parsing and sanitization of the PR body with a more robust approach using the GitHub CLI, ensuring the full PR body is included along with build metadata.

**Workflow improvements:**

* The steps that previously parsed and sanitized the PR body (`Parse PR body`) have been replaced with a new step (`Get PR body`) that uses the GitHub CLI (`gh api`) to fetch the PR body and appends build information such as version and commit SHA. This ensures the body is complete and consistently formatted. (`.github/workflows/nightly.yml`, `.github/workflows/release.yml`) [[1]](diffhunk://#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6L190-R206) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L140-R149)
* All downstream steps that reference the PR body now use the new output (`FULL_BODY`) from the updated step, ensuring that releases and notifications contain the improved and complete PR body. (`.github/workflows/nightly.yml`)Replaces manual PR body parsing with GitHub CLI API calls in nightly and release workflows. This change simplifies body formatting and ensures additional build information is appended consistently.