### PR TITLE
Bump version to 0.1.11

### DIFF
--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -4,8 +4,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     
-    <Version>0.1.10</Version>
-    <AssemblyVersion>0.1.10</AssemblyVersion>
+    <Version>0.1.11</Version>
+    <AssemblyVersion>0.1.11</AssemblyVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>


### PR DESCRIPTION
This PR bumps the application version to 0.1.11.
The change was produced automatically by the CI nightly workflow.