### PR TITLE
Improve logout and cookie handling for reverse proxy

### DIFF
--- a/listenarr.api/Controllers/AccountController.cs
+++ b/listenarr.api/Controllers/AccountController.cs
@@ -101,8 +101,9 @@ namespace Listenarr.Api.Controllers
             }
         }
 
-        [HttpPost("logout")]
-        public async Task<IActionResult> Logout()
+    [HttpPost("logout")]
+    [AllowAnonymous]
+    public async Task<IActionResult> Logout()
         {
             var username = User?.Identity?.Name ?? "Anonymous";
             var authType = User?.Identity?.AuthenticationType ?? "Unknown";


### PR DESCRIPTION
This pull request improves authentication and cookie handling, especially for scenarios where the frontend and backend are on different origins or behind a reverse proxy. The changes ensure that cookies are set and cleared correctly for cross-origin authentication and logout flows.

**Authentication and Cookie Policy Improvements:**

* Updated the cookie `SameSite` policy to use `None` in production (for cross-origin support) and `Lax` in development, ensuring authentication works when the frontend is hosted on a different origin.
* Enhanced the logout event to explicitly overwrite the authentication cookie with an expired one using the same attributes, guaranteeing proper cookie removal even when behind a proxy.

**API Endpoint Adjustments:**

* Added the `[AllowAnonymous]` attribute to the `Logout` endpoint in `AccountController`, allowing unauthenticated users to call the logout route (useful for cleaning up cookies after session expiration).