### PR TITLE
Add completed file action setting and finalize logic

### DIFF
--- a/fe/src/types/index.ts
+++ b/fe/src/types/index.ts
@@ -139,6 +139,8 @@ export interface ApplicationSettings {
   pollingIntervalSeconds: number
   enableNotifications: boolean
   allowedFileExtensions: string[]
+  // Action to perform for completed downloads: 'Move' or 'Copy'
+  completedFileAction?: 'Move' | 'Copy'
   // Optional admin credentials used when saving settings to create/update an initial admin user
   adminUsername?: string
   adminPassword?: string

--- a/fe/src/views/SettingsView.vue
+++ b/fe/src/views/SettingsView.vue
@@ -471,6 +471,15 @@
                 <code>{Quality}</code> - Audio quality
               </span>
             </div>
+
+            <div class="form-group">
+              <label>Completed File Action</label>
+              <select v-model="settings.completedFileAction">
+                <option value="Move">Move (default)</option>
+                <option value="Copy">Copy</option>
+              </select>
+              <span class="form-help">Choose whether completed downloads should be moved into the library output path or copied and left in the client's folder.</span>
+            </div>
           </div>
 
           <div class="form-section">
@@ -1217,6 +1226,10 @@ onMounted(async () => {
   ])
   
   settings.value = configStore.applicationSettings
+  // Ensure completedFileAction has a sensible default
+  if (settings.value && !settings.value.completedFileAction) {
+    settings.value.completedFileAction = 'Move'
+  }
   // Load startup config (optional) to determine AuthenticationRequired
   try {
     startupConfig.value = await apiService.getStartupConfig()

--- a/listenarr.api/Models/Configuration.cs
+++ b/listenarr.api/Models/Configuration.cs
@@ -89,6 +89,9 @@ namespace Listenarr.Api.Models
         public bool EnableNotifications { get; set; } = false;
         public List<string> AllowedFileExtensions { get; set; } = new() { ".mp3", ".flac", ".m4a", ".m4b", ".ogg" };
 
+    // Action to take when a download completes: "Move" or "Copy"
+    public string CompletedFileAction { get; set; } = "Move";
+
         // Optional admin credentials submitted from the UI when saving settings.
         // These are NOT mapped to the ApplicationSettings table; they are used to create/update
         // a User record in the Users table via the ConfigurationService.

--- a/listenarr.api/Services/DownloadMonitorService.cs
+++ b/listenarr.api/Services/DownloadMonitorService.cs
@@ -34,6 +34,9 @@ namespace Listenarr.Api.Services
         private readonly ILogger<DownloadMonitorService> _logger;
         private readonly TimeSpan _pollingInterval = TimeSpan.FromSeconds(10);
         private readonly Dictionary<string, Download> _lastDownloadStates = new();
+    // Tracks downloads that appear complete and the time they were first observed complete
+    private readonly Dictionary<string, DateTime> _completionCandidates = new();
+    private readonly TimeSpan _completionStableWindow = TimeSpan.FromSeconds(10);
 
         public DownloadMonitorService(
             IServiceScopeFactory serviceScopeFactory,
@@ -162,10 +165,105 @@ namespace Listenarr.Api.Services
             ListenArrDbContext dbContext,
             CancellationToken cancellationToken)
         {
-            // TODO: Implement qBittorrent API polling
-            // Get torrent list, match by hash/name, update progress
-            _logger.LogDebug("Polling qBittorrent client {ClientName}", client.Name);
-            return Task.CompletedTask;
+            return Task.Run(async () =>
+            {
+                _logger.LogDebug("Polling qBittorrent client {ClientName}", client.Name);
+                try
+                {
+                    var baseUrl = $"{(client.UseSSL ? "https" : "http")}://{client.Host}:{client.Port}";
+
+                    using var http = new HttpClient();
+
+                    // Login
+                    var loginData = new FormUrlEncodedContent(new[]
+                    {
+                        new KeyValuePair<string, string>("username", client.Username),
+                        new KeyValuePair<string, string>("password", client.Password)
+                    });
+                    var loginResp = await http.PostAsync($"{baseUrl}/api/v2/auth/login", loginData, cancellationToken);
+                    if (!loginResp.IsSuccessStatusCode)
+                    {
+                        _logger.LogWarning("qBittorrent login failed for client {ClientName}", client.Name);
+                        return;
+                    }
+
+                    var torrentsResp = await http.GetAsync($"{baseUrl}/api/v2/torrents/info", cancellationToken);
+                    if (!torrentsResp.IsSuccessStatusCode)
+                    {
+                        _logger.LogWarning("Failed to fetch torrents from qBittorrent for {ClientName}", client.Name);
+                        return;
+                    }
+
+                    var json = await torrentsResp.Content.ReadAsStringAsync(cancellationToken);
+                    var torrents = System.Text.Json.JsonSerializer.Deserialize<List<Dictionary<string, System.Text.Json.JsonElement>>>(json);
+                    if (torrents == null) return;
+
+                    // Build quick lookup by name and save_path
+                    var torrentLookup = new List<(string Name, string SavePath, double Progress, long AmountLeft, string State)>();
+                    foreach (var t in torrents)
+                    {
+                        var name = t.ContainsKey("name") ? t["name"].GetString() ?? "" : "";
+                        var savePath = t.ContainsKey("save_path") ? t["save_path"].GetString() ?? "" : "";
+                        var progress = t.ContainsKey("progress") ? t["progress"].GetDouble() : 0.0;
+                        var amountLeft = t.ContainsKey("amount_left") ? t["amount_left"].GetInt64() : 0L;
+                        var state = t.ContainsKey("state") ? t["state"].GetString() ?? "" : "";
+                        torrentLookup.Add((name, savePath, progress, amountLeft, state));
+                    }
+
+                    // For each DB download associated with this client, try to find matching torrent
+                    foreach (var dl in downloads)
+                    {
+                        try
+                        {
+                            // Match by title or remote path
+                            var matched = torrentLookup.FirstOrDefault(t =>
+                                string.Equals(t.Name, dl.Title, StringComparison.OrdinalIgnoreCase) ||
+                                (!string.IsNullOrEmpty(dl.DownloadPath) && !string.IsNullOrEmpty(t.SavePath) && t.SavePath.Contains(dl.DownloadPath))
+                            );
+
+                            if (matched.Name == null) continue;
+
+                            var isComplete = matched.Progress >= 1.0 || matched.AmountLeft == 0 || matched.State?.ToLower().Contains("upload") == true || matched.State == "completedUP" || matched.State == "completedDL";
+
+                            if (isComplete)
+                            {
+                                // Candidate for completion
+                                if (!_completionCandidates.ContainsKey(dl.Id))
+                                {
+                                    _completionCandidates[dl.Id] = DateTime.UtcNow;
+                                    _logger.LogInformation("Download {DownloadId} observed complete candidate (qBittorrent). Waiting for stability window.", dl.Id);
+                                    continue;
+                                }
+
+                                var firstSeen = _completionCandidates[dl.Id];
+                                if (DateTime.UtcNow - firstSeen >= _completionStableWindow)
+                                {
+                                    // Finalize: attempt to move/copy files and mark complete
+                                    _logger.LogInformation("Download {DownloadId} confirmed complete after stability window. Finalizing.", dl.Id);
+                                    await FinalizeDownloadAsync(dl, matched.SavePath, client, cancellationToken);
+                                    _completionCandidates.Remove(dl.Id);
+                                }
+                            }
+                            else
+                            {
+                                // Not complete anymore - remove candidate if present
+                                if (_completionCandidates.ContainsKey(dl.Id))
+                                {
+                                    _completionCandidates.Remove(dl.Id);
+                                }
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning(ex, "Error processing download {DownloadId} while polling qBittorrent", dl.Id);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Error polling qBittorrent client {ClientName}", client.Name);
+                }
+            }, cancellationToken);
         }
 
         private Task PollTransmissionAsync(
@@ -174,9 +272,243 @@ namespace Listenarr.Api.Services
             ListenArrDbContext dbContext,
             CancellationToken cancellationToken)
         {
-            // TODO: Implement Transmission API polling
-            _logger.LogDebug("Polling Transmission client {ClientName}", client.Name);
-            return Task.CompletedTask;
+            return Task.Run(async () =>
+            {
+                _logger.LogDebug("Polling Transmission client {ClientName}", client.Name);
+                try
+                {
+                    var baseUrl = $"{(client.UseSSL ? "https" : "http")}://{client.Host}:{client.Port}/transmission/rpc";
+                    using var http = new HttpClient();
+
+                    // Get session id
+                    string sessionId = string.Empty;
+                    try
+                    {
+                        // Request to get session id (session-get)
+                        var dummy = new { method = "session-get", tag = 0 };
+                        var dummyContent = new StringContent(System.Text.Json.JsonSerializer.Serialize(dummy), System.Text.Encoding.UTF8, "application/json");
+                        var dummyResp = await http.PostAsync(baseUrl, dummyContent, cancellationToken);
+                        if (dummyResp.Headers.TryGetValues("X-Transmission-Session-Id", out var sids))
+                        {
+                            sessionId = sids.First();
+                        }
+                    }
+                    catch { }
+
+                    // Request torrent-get for fields we need
+                    var rpc = new
+                    {
+                        method = "torrent-get",
+                        arguments = new
+                        {
+                            fields = new[] { "id", "name", "percentDone", "leftUntilDone", "isFinished", "status", "downloadDir" }
+                        },
+                        tag = 4
+                    };
+
+                    var content = new StringContent(System.Text.Json.JsonSerializer.Serialize(rpc), System.Text.Encoding.UTF8, "application/json");
+                    if (!string.IsNullOrEmpty(sessionId)) content.Headers.Add("X-Transmission-Session-Id", sessionId);
+
+                    var resp = await http.PostAsync(baseUrl, content, cancellationToken);
+                    if (!resp.IsSuccessStatusCode) return;
+                    var respText = await resp.Content.ReadAsStringAsync(cancellationToken);
+                    var doc = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(respText);
+                    if (!doc.TryGetProperty("arguments", out var args) || !args.TryGetProperty("torrents", out var torrents) || torrents.ValueKind != System.Text.Json.JsonValueKind.Array) return;
+
+                    foreach (var dl in downloads)
+                    {
+                        try
+                        {
+                            // Attempt to match by name or download dir
+                            var matching = torrents.EnumerateArray().FirstOrDefault(t =>
+                            {
+                                var name = t.TryGetProperty("name", out var n) ? n.GetString() ?? string.Empty : string.Empty;
+                                var dir = t.TryGetProperty("downloadDir", out var d) ? d.GetString() ?? string.Empty : string.Empty;
+                                return string.Equals(name, dl.Title, StringComparison.OrdinalIgnoreCase) || (!string.IsNullOrEmpty(dl.DownloadPath) && dir.Contains(dl.DownloadPath));
+                            });
+
+                            if (matching.ValueKind == System.Text.Json.JsonValueKind.Undefined) continue;
+
+                            var percent = matching.TryGetProperty("percentDone", out var p) ? p.GetDouble() : 0.0;
+                            var left = matching.TryGetProperty("leftUntilDone", out var l) ? l.GetInt64() : 0L;
+                            var isFinished = matching.TryGetProperty("isFinished", out var f) ? f.GetBoolean() : false;
+
+                            var isComplete = percent >= 1.0 || left == 0 || isFinished;
+
+                            if (isComplete)
+                            {
+                                if (!_completionCandidates.ContainsKey(dl.Id))
+                                {
+                                    _completionCandidates[dl.Id] = DateTime.UtcNow;
+                                    _logger.LogInformation("Download {DownloadId} observed complete candidate (Transmission). Waiting for stability window.", dl.Id);
+                                    continue;
+                                }
+
+                                var firstSeen = _completionCandidates[dl.Id];
+                                if (DateTime.UtcNow - firstSeen >= _completionStableWindow)
+                                {
+                                    // Determine downloadDir
+                                    var downloadDir = matching.TryGetProperty("downloadDir", out var dprop) ? dprop.GetString() ?? string.Empty : string.Empty;
+                                    _logger.LogInformation("Download {DownloadId} confirmed complete after stability window (Transmission). Finalizing.", dl.Id);
+                                    await FinalizeDownloadAsync(dl, downloadDir, client, cancellationToken);
+                                    _completionCandidates.Remove(dl.Id);
+                                }
+                            }
+                            else
+                            {
+                                if (_completionCandidates.ContainsKey(dl.Id)) _completionCandidates.Remove(dl.Id);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning(ex, "Error processing download {DownloadId} while polling Transmission", dl.Id);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Error polling Transmission client {ClientName}", client.Name);
+                }
+            }, cancellationToken);
+        }
+
+        /// <summary>
+        /// Attempt to finalize a download after it is observed complete on the client.
+        /// This will try to locate the downloaded file(s) under clientPath and move or copy
+        /// the best candidate to the final destination determined by the file naming service
+        /// or settings.OutputPath.
+        /// </summary>
+        private async Task FinalizeDownloadAsync(Download download, string clientPath, DownloadClientConfiguration client, CancellationToken cancellationToken)
+        {
+            try
+            {
+                using var scope = _serviceScopeFactory.CreateScope();
+                var configService = scope.ServiceProvider.GetRequiredService<IConfigurationService>();
+                var fileNaming = scope.ServiceProvider.GetService<IFileNamingService>();
+                var downloadService = scope.ServiceProvider.GetRequiredService<IDownloadService>();
+                var db = scope.ServiceProvider.GetRequiredService<ListenArrDbContext>();
+
+                var settings = await configService.GetApplicationSettingsAsync();
+
+                // Determine localPath (apply remote path mapping if needed)
+                string localPath = clientPath;
+                if (!string.IsNullOrEmpty(localPath))
+                {
+                    try
+                    {
+                        var pathMapper = scope.ServiceProvider.GetService<IRemotePathMappingService>();
+                        if (pathMapper != null)
+                        {
+                            localPath = await pathMapper.TranslatePathAsync(client.Id, clientPath);
+                        }
+                    }
+                    catch { }
+                }
+
+                string sourceFile = string.Empty;
+
+                if (!string.IsNullOrEmpty(localPath) && Directory.Exists(localPath))
+                {
+                    // Try to find a file that matches the download title and allowed extensions
+                    var files = Directory.GetFiles(localPath, "*.*", SearchOption.AllDirectories)
+                        .Where(f => settings.AllowedFileExtensions.Any(ext => f.EndsWith(ext, StringComparison.OrdinalIgnoreCase)))
+                        .ToList();
+
+                    if (files.Any())
+                    {
+                        // Prefer a file containing the title
+                        var match = files.FirstOrDefault(f => Path.GetFileName(f).IndexOf(download.Title ?? string.Empty, StringComparison.OrdinalIgnoreCase) >= 0)
+                                    ?? files.OrderByDescending(f => new FileInfo(f).Length).First();
+                        sourceFile = match;
+                    }
+                }
+
+                // Fallback to download.DownloadPath or FinalPath
+                if (string.IsNullOrEmpty(sourceFile))
+                {
+                    if (!string.IsNullOrEmpty(download.FinalPath) && File.Exists(download.FinalPath)) sourceFile = download.FinalPath;
+                    else if (!string.IsNullOrEmpty(download.DownloadPath) && File.Exists(download.DownloadPath)) sourceFile = download.DownloadPath;
+                }
+
+                if (string.IsNullOrEmpty(sourceFile) || !File.Exists(sourceFile))
+                {
+                    _logger.LogWarning("Unable to locate source file for download {DownloadId} during finalization", download.Id);
+                    return;
+                }
+
+                // Determine destination path
+                string destinationPath = string.Empty;
+                try
+                {
+                    if (settings.EnableMetadataProcessing && fileNaming != null)
+                    {
+                        // Try to extract metadata minimally
+                        var metadataService = scope.ServiceProvider.GetService<IMetadataService>();
+                        AudioMetadata metadata = new AudioMetadata { Title = download.Title };
+                        if (metadataService != null)
+                        {
+                            try { metadata = await metadataService.ExtractFileMetadataAsync(sourceFile); } catch { }
+                        }
+                        var ext = Path.GetExtension(sourceFile);
+                        destinationPath = await fileNaming.GenerateFilePathAsync(metadata, null, null, ext);
+                    }
+                    else
+                    {
+                        var outRoot = settings.OutputPath;
+                        if (string.IsNullOrEmpty(outRoot)) outRoot = Path.GetDirectoryName(sourceFile) ?? ".";
+                        var fileName = Path.GetFileName(sourceFile);
+                        destinationPath = Path.Combine(outRoot, fileName);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to generate destination path for download {DownloadId}", download.Id);
+                    destinationPath = Path.Combine(Path.GetDirectoryName(sourceFile) ?? ".", Path.GetFileName(sourceFile));
+                }
+
+                // Ensure destination directory exists
+                try
+                {
+                    var destDir = Path.GetDirectoryName(destinationPath);
+                    if (!string.IsNullOrEmpty(destDir) && !Directory.Exists(destDir)) Directory.CreateDirectory(destDir);
+                }
+                catch { }
+
+                // Move or copy according to settings
+                try
+                {
+                    if (string.Equals(settings.CompletedFileAction, "Copy", StringComparison.OrdinalIgnoreCase))
+                    {
+                        File.Copy(sourceFile, destinationPath, true);
+                        _logger.LogInformation("Copied completed download {DownloadId} from {Source} to {Dest}", download.Id, sourceFile, destinationPath);
+                    }
+                    else
+                    {
+                        // Default to Move
+                        File.Move(sourceFile, destinationPath, true);
+                        _logger.LogInformation("Moved completed download {DownloadId} from {Source} to {Dest}", download.Id, sourceFile, destinationPath);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to move/copy file for download {DownloadId}", download.Id);
+                    return;
+                }
+
+                // Finally, call shared completion handler to update DB and broadcast
+                try
+                {
+                    await downloadService.ProcessCompletedDownloadAsync(download.Id, destinationPath);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error while processing completed download {DownloadId}", download.Id);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "FinalizeDownloadAsync failed for {DownloadId}", download.Id);
+            }
         }
 
         private Task PollSABnzbdAsync(

--- a/listenarr.api/Services/IServices.cs
+++ b/listenarr.api/Services/IServices.cs
@@ -21,6 +21,8 @@ namespace Listenarr.Api.Services
         Task<string> SendToDownloadClientAsync(SearchResult searchResult, string? downloadClientId = null, int? audiobookId = null);
         Task<List<QueueItem>> GetQueueAsync();
         Task<bool> RemoveFromQueueAsync(string downloadId, string? downloadClientId = null);
+        // Exposed for processing completed downloads (move/copy + DB updates)
+        Task ProcessCompletedDownloadAsync(string downloadId, string finalPath);
     }
 
     public interface IMetadataService

--- a/tests/Listenarr.Api.Tests/DownloadMonitorFinalizationTests.cs
+++ b/tests/Listenarr.Api.Tests/DownloadMonitorFinalizationTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Listenarr.Api.Models;
+using Listenarr.Api.Services;
+using Microsoft.AspNetCore.SignalR;
+using Listenarr.Api.Hubs;
+
+namespace Listenarr.Api.Tests
+{
+    public class DownloadMonitorFinalizationTests
+    {
+        private ListenArrDbContext CreateInMemoryDb()
+        {
+            var options = new DbContextOptionsBuilder<ListenArrDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            return new ListenArrDbContext(options);
+        }
+
+        private ServiceProvider BuildServiceProvider(ListenArrDbContext db, Mock<IDownloadService> downloadServiceMock, ApplicationSettings settings)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<ListenArrDbContext>(db);
+            var configMock = new Mock<IConfigurationService>();
+            configMock.Setup(c => c.GetApplicationSettingsAsync()).ReturnsAsync(settings);
+            services.AddSingleton<IConfigurationService>(configMock.Object);
+            services.AddSingleton<IDownloadService>(downloadServiceMock.Object);
+            // Provide a minimal file naming service that won't be used (metadata disabled in settings)
+            var fileNamingMock = new Mock<IFileNamingService>();
+            services.AddSingleton<IFileNamingService>(fileNamingMock.Object);
+            // metadata service
+            var metadataMock = new Mock<IMetadataService>();
+            services.AddSingleton<IMetadataService>(metadataMock.Object);
+
+            return services.BuildServiceProvider();
+        }
+
+        [Fact]
+        public async Task FinalizeDownload_MovesFile_WhenSettingIsMove()
+        {
+            var db = CreateInMemoryDb();
+
+            // Seed download
+            var download = new Download
+            {
+                Id = "d1",
+                Title = "Test Move",
+                Status = DownloadStatus.Downloading,
+                DownloadPath = string.Empty,
+                FinalPath = string.Empty,
+                StartedAt = DateTime.UtcNow
+            };
+            db.Downloads.Add(download);
+            await db.SaveChangesAsync();
+
+            // Create source file
+            var tempDir = Path.Combine(Path.GetTempPath(), "listenarr-test", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            var sourceFile = Path.Combine(tempDir, "Test Move.m4b");
+            await File.WriteAllTextAsync(sourceFile, "dummy");
+
+            // Settings: move to output path
+            var outDir = Path.Combine(Path.GetTempPath(), "listenarr-out", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(outDir);
+            var settings = new ApplicationSettings { OutputPath = outDir, EnableMetadataProcessing = false, CompletedFileAction = "Move" };
+
+            var downloadServiceMock = new Mock<IDownloadService>();
+            downloadServiceMock.Setup(d => d.ProcessCompletedDownloadAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask).Verifiable();
+
+            var provider = BuildServiceProvider(db, downloadServiceMock, settings);
+            var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+            var hubClientsMock = new Mock<IHubClients>();
+            var hubContextMock = new Mock<IHubContext<DownloadHub>>();
+            hubContextMock.SetupGet(h => h.Clients).Returns(hubClientsMock.Object);
+
+            var loggerMock = new Mock<ILogger<DownloadMonitorService>>();
+
+            var monitor = new DownloadMonitorService(scopeFactory, hubContextMock.Object, loggerMock.Object);
+
+            // Invoke private FinalizeDownloadAsync via reflection
+            var method = typeof(DownloadMonitorService).GetMethod("FinalizeDownloadAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+
+            var clientConfig = new DownloadClientConfiguration { Id = "c1", Name = "Local", DownloadPath = tempDir };
+
+            var task = (Task?)method.Invoke(monitor, new object[] { download, tempDir, clientConfig, CancellationToken.None });
+            if (task != null) await task;
+
+            // Expect file moved to output
+            var destFile = Path.Combine(outDir, Path.GetFileName(sourceFile));
+            Assert.True(File.Exists(destFile));
+            Assert.False(File.Exists(sourceFile));
+            downloadServiceMock.Verify(d => d.ProcessCompletedDownloadAsync(download.Id, It.Is<string>(s => s == destFile)), Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public async Task FinalizeDownload_CopiesFile_WhenSettingIsCopy()
+        {
+            var db = CreateInMemoryDb();
+
+            // Seed download
+            var download = new Download
+            {
+                Id = "d2",
+                Title = "Test Copy",
+                Status = DownloadStatus.Downloading,
+                DownloadPath = string.Empty,
+                FinalPath = string.Empty,
+                StartedAt = DateTime.UtcNow
+            };
+            db.Downloads.Add(download);
+            await db.SaveChangesAsync();
+
+            // Create source file
+            var tempDir = Path.Combine(Path.GetTempPath(), "listenarr-test", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            var sourceFile = Path.Combine(tempDir, "Test Copy.m4b");
+            await File.WriteAllTextAsync(sourceFile, "dummy");
+
+            // Settings: copy to output path
+            var outDir = Path.Combine(Path.GetTempPath(), "listenarr-out", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(outDir);
+            var settings = new ApplicationSettings { OutputPath = outDir, EnableMetadataProcessing = false, CompletedFileAction = "Copy" };
+
+            var downloadServiceMock = new Mock<IDownloadService>();
+            downloadServiceMock.Setup(d => d.ProcessCompletedDownloadAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask).Verifiable();
+
+            var provider = BuildServiceProvider(db, downloadServiceMock, settings);
+            var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+            var hubClientsMock = new Mock<IHubClients>();
+            var hubContextMock = new Mock<IHubContext<DownloadHub>>();
+            hubContextMock.SetupGet(h => h.Clients).Returns(hubClientsMock.Object);
+
+            var loggerMock = new Mock<ILogger<DownloadMonitorService>>();
+
+            var monitor = new DownloadMonitorService(scopeFactory, hubContextMock.Object, loggerMock.Object);
+
+            var method = typeof(DownloadMonitorService).GetMethod("FinalizeDownloadAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+
+            var clientConfig = new DownloadClientConfiguration { Id = "c2", Name = "Local", DownloadPath = tempDir };
+
+            var task = (Task?)method.Invoke(monitor, new object[] { download, tempDir, clientConfig, CancellationToken.None });
+            if (task != null) await task;
+
+            // Expect file copied to output
+            var destFile = Path.Combine(outDir, Path.GetFileName(sourceFile));
+            Assert.True(File.Exists(destFile));
+            Assert.True(File.Exists(sourceFile));
+            downloadServiceMock.Verify(d => d.ProcessCompletedDownloadAsync(download.Id, It.Is<string>(s => s == destFile)), Times.AtLeastOnce);
+        }
+    }
+}

--- a/tests/Listenarr.Api.Tests/Listenarr.Api.Tests.csproj
+++ b/tests/Listenarr.Api.Tests/Listenarr.Api.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+  <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -9,8 +9,8 @@
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.17" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.10" />
+  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
+  <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
     <PackageReference Include="Moq" Version="4.20.3" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull request introduces the ability to configure how completed downloads are handled, allowing users to choose whether files are moved or copied into the library output path. It also implements finalized download handling for qBittorrent and Transmission clients, ensuring files are reliably transferred and marked complete after a stability window. The UI and backend have been updated to support this new setting, and download completion logic has been consolidated and exposed for easier testing and maintenance.

**Completed Download Handling Improvements**
* Added a new `completedFileAction` setting to both frontend (`ApplicationSettings` interface in `index.ts`) and backend (`ApplicationSettings` class in `Configuration.cs`) to let users choose between moving or copying completed downloads. [[1]](diffhunk://#diff-5237e5b4d2e4893b9dcb2564e9ff4a33a7d71c2732caa9601300771db59d6577R142-R143) [[2]](diffhunk://#diff-6718774e5764356f8b983cd1496026636f56c6d06d6cb23db55ab8ca7d9c2c1aR92-R94)
* Updated the Settings UI in `SettingsView.vue` to include a dropdown for selecting the completed file action, with sensible defaulting to "Move". [[1]](diffhunk://#diff-9bb43492c5cdc5db4bb47bfd3b1ed43b7c4c7b9db37e8fb365b5b99772760ebfR474-R482) [[2]](diffhunk://#diff-9bb43492c5cdc5db4bb47bfd3b1ed43b7c4c7b9db37e8fb365b5b99772760ebfR1229-R1232)

**Download Monitoring and Finalization**
* Implemented logic in `DownloadMonitorService` to poll qBittorrent and Transmission clients, detect completed downloads, and after a short stability window, finalize them by moving/copying files according to the new setting. [[1]](diffhunk://#diff-9455c037db641f05127ac9f2a73038ef469922ccdfd15dd94469f4353ab3368bL165-R266) [[2]](diffhunk://#diff-9455c037db641f05127ac9f2a73038ef469922ccdfd15dd94469f4353ab3368bL177-R511)
* Added a `FinalizeDownloadAsync` method to handle locating the correct file, determining the destination path, and moving or copying the file as configured, then updating the database and broadcasting completion.

**API and Test Support**
* Exposed a new method `ProcessCompletedDownloadAsync` in the `IDownloadService` interface for processing completed downloads, improving modularity and testability.
* Added `Moq` as a test dependency for mocking services in unit tests.