### PR TITLE
Handle empty strings in value conversions for EF models

### DIFF
--- a/listenarr.api/Models/ListenArrDbContext.cs
+++ b/listenarr.api/Models/ListenArrDbContext.cs
@@ -145,7 +145,9 @@ namespace Listenarr.Api.Models
                 .Property(e => e.Metadata)
                 .HasConversion(
                     v => System.Text.Json.JsonSerializer.Serialize(v, (System.Text.Json.JsonSerializerOptions?)null),
-                    v => System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(v, (System.Text.Json.JsonSerializerOptions?)null) ?? new Dictionary<string, object>()
+                    v => string.IsNullOrWhiteSpace(v)
+                        ? new Dictionary<string, object>()
+                        : System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(v, (System.Text.Json.JsonSerializerOptions?)null) ?? new Dictionary<string, object>()
                 );
             modelBuilder.Entity<Download>()
                 .Property(e => e.Metadata)
@@ -160,7 +162,9 @@ namespace Listenarr.Api.Models
                 .Property(e => e.Qualities)
                 .HasConversion(
                     v => System.Text.Json.JsonSerializer.Serialize(v, (System.Text.Json.JsonSerializerOptions?)null),
-                    v => System.Text.Json.JsonSerializer.Deserialize<List<QualityDefinition>>(v, (System.Text.Json.JsonSerializerOptions?)null) ?? new List<QualityDefinition>()
+                    v => string.IsNullOrWhiteSpace(v)
+                        ? new List<QualityDefinition>()
+                        : System.Text.Json.JsonSerializer.Deserialize<List<QualityDefinition>>(v, (System.Text.Json.JsonSerializerOptions?)null) ?? new List<QualityDefinition>()
                 );
             modelBuilder.Entity<QualityProfile>()
                 .Property(e => e.Qualities)
@@ -174,7 +178,7 @@ namespace Listenarr.Api.Models
                 .Property(e => e.PreferredFormats)
                 .HasConversion(
                     v => string.Join("|", v ?? new List<string>()),
-                    v => v.Split('|', System.StringSplitOptions.RemoveEmptyEntries).ToList()
+                    v => string.IsNullOrWhiteSpace(v) ? new List<string>() : v.Split('|', System.StringSplitOptions.RemoveEmptyEntries).ToList()
                 );
             modelBuilder.Entity<QualityProfile>()
                 .Property(e => e.PreferredFormats)
@@ -188,7 +192,7 @@ namespace Listenarr.Api.Models
                 .Property(e => e.PreferredWords)
                 .HasConversion(
                     v => string.Join("|", v ?? new List<string>()),
-                    v => v.Split('|', System.StringSplitOptions.RemoveEmptyEntries).ToList()
+                    v => string.IsNullOrWhiteSpace(v) ? new List<string>() : v.Split('|', System.StringSplitOptions.RemoveEmptyEntries).ToList()
                 );
             modelBuilder.Entity<QualityProfile>()
                 .Property(e => e.PreferredWords)
@@ -202,7 +206,7 @@ namespace Listenarr.Api.Models
                 .Property(e => e.MustNotContain)
                 .HasConversion(
                     v => string.Join("|", v ?? new List<string>()),
-                    v => v.Split('|', System.StringSplitOptions.RemoveEmptyEntries).ToList()
+                    v => string.IsNullOrWhiteSpace(v) ? new List<string>() : v.Split('|', System.StringSplitOptions.RemoveEmptyEntries).ToList()
                 );
             modelBuilder.Entity<QualityProfile>()
                 .Property(e => e.MustNotContain)
@@ -216,7 +220,7 @@ namespace Listenarr.Api.Models
                 .Property(e => e.MustContain)
                 .HasConversion(
                     v => string.Join("|", v ?? new List<string>()),
-                    v => v.Split('|', System.StringSplitOptions.RemoveEmptyEntries).ToList()
+                    v => string.IsNullOrWhiteSpace(v) ? new List<string>() : v.Split('|', System.StringSplitOptions.RemoveEmptyEntries).ToList()
                 );
             modelBuilder.Entity<QualityProfile>()
                 .Property(e => e.MustContain)
@@ -230,7 +234,7 @@ namespace Listenarr.Api.Models
                 .Property(e => e.PreferredLanguages)
                 .HasConversion(
                     v => string.Join("|", v ?? new List<string>()),
-                    v => v.Split('|', System.StringSplitOptions.RemoveEmptyEntries).ToList()
+                    v => string.IsNullOrWhiteSpace(v) ? new List<string>() : v.Split('|', System.StringSplitOptions.RemoveEmptyEntries).ToList()
                 );
             modelBuilder.Entity<QualityProfile>()
                 .Property(e => e.PreferredLanguages)
@@ -245,7 +249,9 @@ namespace Listenarr.Api.Models
                 .Property(e => e.JobData)
                 .HasConversion(
                     v => System.Text.Json.JsonSerializer.Serialize(v, (System.Text.Json.JsonSerializerOptions?)null),
-                    v => System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(v, (System.Text.Json.JsonSerializerOptions?)null) ?? new Dictionary<string, object>()
+                    v => string.IsNullOrWhiteSpace(v)
+                        ? new Dictionary<string, object>()
+                        : System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(v, (System.Text.Json.JsonSerializerOptions?)null) ?? new Dictionary<string, object>()
                 );
             modelBuilder.Entity<DownloadProcessingJob>()
                 .Property(e => e.JobData)
@@ -259,7 +265,9 @@ namespace Listenarr.Api.Models
                 .Property(e => e.ProcessingLog)
                 .HasConversion(
                     v => System.Text.Json.JsonSerializer.Serialize(v, (System.Text.Json.JsonSerializerOptions?)null),
-                    v => System.Text.Json.JsonSerializer.Deserialize<List<string>>(v, (System.Text.Json.JsonSerializerOptions?)null) ?? new List<string>()
+                    v => string.IsNullOrWhiteSpace(v)
+                        ? new List<string>()
+                        : System.Text.Json.JsonSerializer.Deserialize<List<string>>(v, (System.Text.Json.JsonSerializerOptions?)null) ?? new List<string>()
                 );
             modelBuilder.Entity<DownloadProcessingJob>()
                 .Property(e => e.ProcessingLog)


### PR DESCRIPTION
This pull request improves the robustness of entity property conversions in `listenarr.api/Models/ListenArrDbContext.cs` by ensuring that deserialization gracefully handles empty or null database values. The changes prevent errors during deserialization and ensure properties are initialized with empty collections when appropriate.

**Improvements to deserialization and property initialization:**

* Updated JSON deserialization for properties like `Metadata`, `Qualities`, `JobData`, and `ProcessingLog` to check for null or whitespace before attempting to deserialize, defaulting to empty collections when necessary. [[1]](diffhunk://#diff-860611c46b6e9be7d253c7114a7741a8fc20b17bf37d75da304d4e1f5b37b3bdL148-R150) [[2]](diffhunk://#diff-860611c46b6e9be7d253c7114a7741a8fc20b17bf37d75da304d4e1f5b37b3bdL163-R167) [[3]](diffhunk://#diff-860611c46b6e9be7d253c7114a7741a8fc20b17bf37d75da304d4e1f5b37b3bdL248-R254) [[4]](diffhunk://#diff-860611c46b6e9be7d253c7114a7741a8fc20b17bf37d75da304d4e1f5b37b3bdL262-R270)
* Enhanced string-to-list conversions for properties such as `PreferredFormats`, `PreferredWords`, `MustNotContain`, `MustContain`, and `PreferredLanguages` to return empty lists when the database value is null or whitespace, preventing exceptions and ensuring consistent initialization. [[1]](diffhunk://#diff-860611c46b6e9be7d253c7114a7741a8fc20b17bf37d75da304d4e1f5b37b3bdL177-R181) [[2]](diffhunk://#diff-860611c46b6e9be7d253c7114a7741a8fc20b17bf37d75da304d4e1f5b37b3bdL191-R195) [[3]](diffhunk://#diff-860611c46b6e9be7d253c7114a7741a8fc20b17bf37d75da304d4e1f5b37b3bdL205-R209) [[4]](diffhunk://#diff-860611c46b6e9be7d253c7114a7741a8fc20b17bf37d75da304d4e1f5b37b3bdL219-R223) [[5]](diffhunk://#diff-860611c46b6e9be7d253c7114a7741a8fc20b17bf37d75da304d4e1f5b37b3bdL233-R237)