### PR TITLE
Add global toast notification system

### DIFF
--- a/fe/src/components/AddLibraryModal.vue
+++ b/fe/src/components/AddLibraryModal.vue
@@ -146,7 +146,7 @@ import { ref, onMounted } from 'vue'
 import type { AudibleBookMetadata, QualityProfile, Audiobook } from '@/types'
 import { apiService } from '@/services/api'
 import { useConfigurationStore } from '@/stores/configuration'
-import { useNotification } from '@/composables/useNotification'
+import { useToast } from '@/services/toastService'
 
 interface Props {
   visible: boolean
@@ -162,7 +162,7 @@ const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
 
 const configStore = useConfigurationStore()
-const { success, error: showError } = useNotification()
+const toast = useToast()
 
 const isAdding = ref(false)
 const qualityProfiles = ref<QualityProfile[]>([])
@@ -194,13 +194,13 @@ const addToLibrary = async () => {
       autoSearch: options.value.autoSearch
     })
 
-    success(`"${props.book.title}" has been added to your library!`)
+  toast.success('Added', `"${props.book.title}" has been added to your library!`)
     emit('added', result.audiobook)
     closeModal()
   } catch (err: unknown) {
     console.error('Failed to add audiobook:', err)
     const errorMessage = err instanceof Error ? err.message : 'Failed to add audiobook. Please try again.'
-    showError(errorMessage)
+  toast.error('Add failed', errorMessage)
   } finally {
     isAdding.value = false
   }

--- a/fe/src/components/BulkEditModal.vue
+++ b/fe/src/components/BulkEditModal.vue
@@ -152,7 +152,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import { apiService } from '@/services/api'
-import { useNotification } from '@/composables/useNotification'
+import { useToast } from '@/services/toastService'
 import type { QualityProfile } from '@/types'
 
 interface Props {
@@ -191,7 +191,7 @@ const hasChanges = computed(() => {
          formData.value.rootFolder !== null
 })
 
-const { success, error: showError } = useNotification()
+const toast = useToast()
 
 watch(() => props.isOpen, async (isOpen) => {
   if (isOpen) {
@@ -271,7 +271,7 @@ async function handleSave() {
 
   // Count successes
   const successCount = results.value.filter(r => r.success).length
-  success(`Updated ${successCount} of ${results.value.length} audiobook(s)`)
+  toast.success('Bulk update', `Updated ${successCount} of ${results.value.length} audiobook(s)`)
 
   // Notify parent and leave modal open so user can review results
   emit('saved')
@@ -307,7 +307,7 @@ async function handleSave() {
     } catch {
       // fallback
     }
-    showError(message)
+  toast.error('Bulk update failed', message)
   } finally {
     saving.value = false
   }

--- a/fe/src/components/DownloadClientFormModal.vue
+++ b/fe/src/components/DownloadClientFormModal.vue
@@ -287,7 +287,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import type { DownloadClientConfiguration } from '@/types'
-import { useNotification } from '@/composables/useNotification'
+import { useToast } from '@/services/toastService'
 import { useConfigurationStore } from '@/stores/configuration'
 import RemotePathMappingsManager from './RemotePathMappingsManager.vue'
 
@@ -305,7 +305,7 @@ interface Emits {
 const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
 const configStore = useConfigurationStore()
-const { success, error: showError } = useNotification()
+const toast = useToast()
 
 const saving = ref(false)
 const testing = ref(false)
@@ -428,10 +428,10 @@ const testConnection = async () => {
   try {
     // TODO: Implement actual test endpoint
     await new Promise(resolve => setTimeout(resolve, 1000))
-    success('Connection test successful')
+    toast.success('Test successful', 'Connection test successful')
   } catch (error) {
     console.error('Failed to test download client:', error)
-    showError('Failed to test download client connection')
+    toast.error('Test failed', 'Failed to test download client connection')
   } finally {
     testing.value = false
   }
@@ -471,15 +471,15 @@ const handleSubmit = async () => {
       }
     }
 
-    console.log('Saving download client configuration:', clientConfig)
-    await configStore.saveDownloadClientConfiguration(clientConfig)
-    success(`Download client ${props.editingClient ? 'updated' : 'created'} successfully`)
+  console.log('Saving download client configuration:', clientConfig)
+  await configStore.saveDownloadClientConfiguration(clientConfig)
+  toast.success('Saved', `Download client ${props.editingClient ? 'updated' : 'created'} successfully`)
     
     emit('saved')
     closeModal()
   } catch (error) {
-    console.error('Failed to save download client:', error)
-    showError(`Failed to save download client: ${error instanceof Error ? error.message : 'Unknown error'}`)
+  console.error('Failed to save download client:', error)
+  toast.error('Save failed', `Failed to save download client: ${error instanceof Error ? error.message : 'Unknown error'}`)
   } finally {
     saving.value = false
   }

--- a/fe/src/components/EditAudiobookModal.vue
+++ b/fe/src/components/EditAudiobookModal.vue
@@ -98,6 +98,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import { useToast } from '@/services/toastService'
 import { apiService } from '@/services/api'
 import type { Audiobook, QualityProfile } from '@/types'
 
@@ -183,7 +184,8 @@ async function handleSave() {
     close()
   } catch (error) {
     console.error('Failed to save audiobook edits:', error)
-    alert('Failed to save changes. Please try again.')
+    const toast = useToast()
+    toast.error('Save failed', 'Failed to save changes. Please try again.')
   } finally {
     saving.value = false
   }

--- a/fe/src/components/GlobalToast.vue
+++ b/fe/src/components/GlobalToast.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="toast-container" aria-live="polite" aria-atomic="true">
+    <transition-group name="toast" tag="div">
+      <div v-for="t in toasts" :key="t.id" :class="['toast', t.level]">
+        <div class="toast-title">{{ t.title }}</div>
+        <div class="toast-message">{{ t.message }}</div>
+        <button class="toast-close" @click="dismiss(t.id)">×</button>
+      </div>
+    </transition-group>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onUnmounted, reactive } from 'vue'
+import { useToast } from '@/services/toastService'
+
+const { subscribe, toasts: toastsRef, dismiss } = useToast()
+const toasts = toastsRef
+
+onUnmounted(() => {
+  // cleanup if necessary
+})
+</script>
+
+<style scoped>
+.toast-container { position: fixed; right: 20px; top: 80px; z-index: 2000; display: flex; flex-direction: column; gap: 8px; }
+.toast { min-width: 260px; max-width: 380px; padding: 12px 14px; border-radius: 8px; color: #fff; box-shadow: 0 6px 20px rgba(0,0,0,0.45); position: relative; overflow: hidden; }
+.toast .toast-title { font-weight: 700; margin-bottom: 4px; }
+.toast .toast-message { font-size: 13px; color: #f3f3f3; }
+.toast .toast-close { position: absolute; top: 6px; right: 8px; background: transparent; border: none; color: #fff; font-size: 16px; cursor: pointer; }
+.toast.info { background: linear-gradient(90deg,#2196F3,#42A5F5); }
+.toast.success { background: linear-gradient(90deg,#4CAF50,#66BB6A); }
+.toast.warning { background: linear-gradient(90deg,#FF9800,#FFB74D); }
+.toast.error { background: linear-gradient(90deg,#E53935,#EF5350); }
+.toast-enter-active, .toast-leave-active { transition: all 300ms ease; }
+.toast-enter-from { transform: translateX(20px); opacity: 0; }
+.toast-leave-to { transform: translateX(20px); opacity: 0; }
+</style>

--- a/fe/src/components/IndexerFormModal.vue
+++ b/fe/src/components/IndexerFormModal.vue
@@ -257,7 +257,7 @@
 import { ref, watch } from 'vue'
 import type { Indexer } from '@/types'
 import { createIndexer, updateIndexer, testIndexer as apiTestIndexer } from '@/services/api'
-import { useNotification } from '@/composables/useNotification'
+import { useToast } from '@/services/toastService'
 
 interface Props {
   visible: boolean
@@ -271,7 +271,7 @@ interface Emits {
 
 const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
-const { success, error: showError } = useNotification()
+const toast = useToast()
 
 const saving = ref(false)
 const testing = ref(false)
@@ -384,7 +384,7 @@ const closeModal = () => {
 
 const testConnection = async () => {
   if (!props.editingIndexer) {
-    showError('Please save the indexer first before testing')
+    toast.error('Save required', 'Please save the indexer first before testing')
     return
   }
 
@@ -392,13 +392,13 @@ const testConnection = async () => {
   try {
     const result = await apiTestIndexer(props.editingIndexer.id)
     if (result.success) {
-      success(`Test successful: ${result.message}`)
+      toast.success('Test successful', result.message || '')
     } else {
-      showError(`Test failed: ${result.error || result.message}`)
+      toast.error('Test failed', result.error || result.message || '')
     }
-  } catch (error) {
+    } catch (error) {
     console.error('Failed to test indexer:', error)
-    showError('Failed to test indexer connection')
+    toast.error('Test failed', 'Failed to test indexer connection')
   } finally {
     testing.value = false
   }
@@ -431,18 +431,18 @@ const handleSubmit = async () => {
     if (props.editingIndexer) {
       // Update existing indexer
       await updateIndexer(props.editingIndexer.id, submitData)
-      success('Indexer updated successfully')
+      toast.success('Indexer saved', 'Indexer updated successfully')
     } else {
       // Create new indexer
       await createIndexer(submitData)
-      success('Indexer created successfully')
+      toast.success('Indexer saved', 'Indexer created successfully')
     }
     
     emit('saved')
     closeModal()
   } catch (error) {
     console.error('Failed to save indexer:', error)
-    showError('Failed to save indexer')
+    toast.error('Save failed', 'Failed to save indexer')
   } finally {
     saving.value = false
   }

--- a/fe/src/components/ManualSearchModal.vue
+++ b/fe/src/components/ManualSearchModal.vue
@@ -182,6 +182,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import { useToast } from '@/services/toastService'
 import { apiService } from '@/services/api'
 import type { Audiobook, SearchResult, QualityScore, QualityProfile, SearchSortBy, SearchSortDirection } from '@/types'
 import { getScoreBreakdownTooltip } from '@/composables/useScore'
@@ -437,6 +438,7 @@ function buildSearchQuery(): string {
 
 async function downloadResult(result: SearchResult) {
   downloading.value[result.id] = true
+  const toast = useToast()
   
   try {
     // Check if this is a DDL
@@ -482,7 +484,8 @@ async function downloadResult(result: SearchResult) {
       userMessage = 'Download path not configured. Please go to Settings and configure the Output Path before downloading.'
     }
     
-    alert(userMessage)
+    // Show error as a non-blocking toast instead of a modal alert
+    toast.error('Download failed', userMessage)
     delete downloading.value[result.id]
   }
 }

--- a/fe/src/components/QualityProfileFormModal.vue
+++ b/fe/src/components/QualityProfileFormModal.vue
@@ -580,21 +580,24 @@ const closeModal = () => {
   emit('close')
 }
 
+import { useToast } from '@/services/toastService'
+
 const handleSubmit = () => {
+  const toast = useToast()
   // Validate at least one quality is selected
   if (!formData.value.qualities.some(q => q.allowed)) {
-    alert('Please select at least one quality')
+    toast.error('Validation', 'Please select at least one quality')
     return
   }
 
   // Validate cutoff quality is selected and allowed
   if (!formData.value.cutoffQuality) {
-    alert('Please select a cutoff quality')
+    toast.error('Validation', 'Please select a cutoff quality')
     return
   }
 
   if (!formData.value.qualities.some(q => q.quality === formData.value.cutoffQuality && q.allowed)) {
-    alert('Cutoff quality must be one of the allowed qualities')
+    toast.error('Validation', 'Cutoff quality must be one of the allowed qualities')
     return
   }
 

--- a/fe/src/services/api.ts
+++ b/fe/src/services/api.ts
@@ -303,6 +303,14 @@ class ApiService {
     return this.request<boolean>(`/configuration/download-clients/${id}`, { method: 'DELETE' })
   }
 
+  async testDownloadClient(config: DownloadClientConfiguration): Promise<{ success: boolean; message: string; client?: DownloadClientConfiguration }>
+  {
+    return this.request<{ success: boolean; message: string; client?: DownloadClientConfiguration }>('/configuration/download-clients/test', {
+      method: 'POST',
+      body: JSON.stringify(config)
+    })
+  }
+
   // Application Settings
   async getApplicationSettings(): Promise<ApplicationSettings> {
     return this.request<ApplicationSettings>('/configuration/settings')
@@ -793,5 +801,8 @@ export const createQualityProfile = (profile: Omit<QualityProfile, 'id' | 'creat
 export const updateQualityProfile = (id: number, profile: Partial<QualityProfile>) => apiService.updateQualityProfile(id, profile)
 export const deleteQualityProfile = (id: number) => apiService.deleteQualityProfile(id)
 export const scoreSearchResults = (profileId: number, searchResults: SearchResult[]) => apiService.scoreSearchResults(profileId, searchResults)
+
+// Download client helpers
+export const testDownloadClient = (config: DownloadClientConfiguration) => apiService.testDownloadClient(config)
 
 

--- a/fe/src/services/signalr.ts
+++ b/fe/src/services/signalr.ts
@@ -28,6 +28,7 @@ class SignalRService {
   private scanJobCallbacks: Set<ScanJobCallback> = new Set()
   private filesRemovedCallbacks: Set<(payload: { audiobookId: number; removed: Array<{ id: number; path: string }> }) => void> = new Set()
   private searchProgressCallbacks: Set<(payload: { message: string; asin?: string | null }) => void> = new Set()
+  private toastCallbacks: Set<(payload: { level: string; title: string; message: string; timeoutMs?: number }) => void> = new Set()
   private pingInterval: number | null = null
 
   async connect(): Promise<void> {
@@ -184,6 +185,12 @@ class SignalRService {
           this.searchProgressCallbacks.forEach(cb => cb(payload))
         }
         break
+      case 'ToastMessage':
+        if (args && args[0]) {
+          const payload = args[0] as { level: string; title: string; message: string; timeoutMs?: number }
+          this.toastCallbacks.forEach(cb => cb(payload))
+        }
+        break
     }
   }
 
@@ -285,6 +292,12 @@ class SignalRService {
   onSearchProgress(callback: (payload: { message: string; asin?: string | null }) => void): () => void {
     this.searchProgressCallbacks.add(callback)
     return () => { this.searchProgressCallbacks.delete(callback) }
+  }
+
+  // Subscribe to server-sent toast messages
+  onToast(callback: (payload: { level: string; title: string; message: string; timeoutMs?: number }) => void): () => void {
+    this.toastCallbacks.add(callback)
+    return () => { this.toastCallbacks.delete(callback) }
   }
 
   // Subscribe to files removed notifications

--- a/fe/src/services/toastService.ts
+++ b/fe/src/services/toastService.ts
@@ -1,0 +1,54 @@
+import { reactive } from 'vue'
+
+type Toast = { id: string; level: string; title: string; message: string; timeoutMs?: number }
+
+const state = reactive<{ toasts: Toast[]; callbacks: Set<(t: Toast[]) => void> }>({ toasts: [], callbacks: new Set() })
+
+function genId() {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2,8)}`
+}
+
+function notifySubscribers() {
+  for (const cb of state.callbacks) {
+    try { cb(state.toasts) } catch { /* swallow subscriber errors */ }
+  }
+}
+
+function push(level: string, title: string, message: string, timeoutMs = 5000) {
+  const t: Toast = { id: genId(), level, title, message, timeoutMs }
+  state.toasts.unshift(t)
+  if (state.toasts.length > 6) state.toasts.pop()
+  notifySubscribers()
+  if (timeoutMs && timeoutMs > 0) {
+    setTimeout(() => { dismiss(t.id) }, timeoutMs)
+  }
+  return t.id
+}
+
+function dismiss(id: string) {
+  const idx = state.toasts.findIndex(t => t.id === id)
+  if (idx >= 0) {
+    state.toasts.splice(idx, 1)
+    notifySubscribers()
+  }
+}
+
+function subscribe(cb: (toasts: Toast[]) => void) {
+  state.callbacks.add(cb)
+  // Invoke immediately with current state
+  try { cb(state.toasts) } catch {}
+  return () => { state.callbacks.delete(cb) }
+}
+
+export function useToast() {
+  return {
+    toasts: state.toasts,
+    push,
+    dismiss,
+    subscribe,
+    info: (title: string, message: string, timeoutMs?: number) => push('info', title, message, timeoutMs),
+    success: (title: string, message: string, timeoutMs?: number) => push('success', title, message, timeoutMs),
+    warning: (title: string, message: string, timeoutMs?: number) => push('warning', title, message, timeoutMs),
+    error: (title: string, message: string, timeoutMs?: number) => push('error', title, message, timeoutMs),
+  }
+}

--- a/fe/src/views/ActivityView.vue
+++ b/fe/src/views/ActivityView.vue
@@ -156,6 +156,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useToast } from '@/services/toastService'
 import { apiService } from '@/services/api'
 import { signalRService } from '@/services/signalr'
 import { useDownloadsStore } from '@/stores/downloads'
@@ -278,7 +279,8 @@ const confirmRemove = async () => {
     itemToRemove.value = null
   } catch (err) {
     console.error('Failed to remove download:', err)
-    alert('Failed to remove download: ' + (err as Error).message)
+    const toast = useToast()
+    toast.error('Remove failed', (err as Error).message)
   } finally {
     removing.value = false
   }

--- a/fe/src/views/AddNewView.vue
+++ b/fe/src/views/AddNewView.vue
@@ -271,7 +271,7 @@ import { useConfigurationStore } from '@/stores/configuration'
 import { useLibraryStore } from '@/stores/library'
 import AudiobookDetailsModal from '@/components/AudiobookDetailsModal.vue'
 import AddLibraryModal from '@/components/AddLibraryModal.vue'
-import { useNotification } from '@/composables/useNotification'
+import { useToast } from '@/services/toastService'
 
 // Extended type for title search results that includes search metadata
 type TitleSearchResult = OpenLibraryBook & { searchResult?: SearchResult }
@@ -279,7 +279,7 @@ type TitleSearchResult = OpenLibraryBook & { searchResult?: SearchResult }
 const router = useRouter()
 const configStore = useConfigurationStore()
 const libraryStore = useLibraryStore()
-const { error: showError, warning } = useNotification()
+const toast = useToast()
 
 // Small helper to decode basic HTML entities (covers &amp;, &lt;, &gt;, &quot;, &#39;)
 const decodeHtml = (input?: string | null): string => {
@@ -632,7 +632,7 @@ const selectTitleResult = async (book: TitleSearchResult) => {
   
   if (!asin) {
     console.error('No ASIN available for selected book')
-    warning('Cannot add to library: No ASIN available')
+    toast.warning('Cannot add', 'Cannot add to library: No ASIN available')
     return
   }
 
@@ -648,7 +648,7 @@ const selectTitleResult = async (book: TitleSearchResult) => {
     await addToLibrary(metadata)
   } catch (error) {
     console.error('Failed to add audiobook:', error)
-    showError('Failed to add audiobook. Please try again.')
+    toast.error('Add failed', 'Failed to add audiobook. Please try again.')
   }
 }
 
@@ -659,9 +659,9 @@ const viewTitleResultDetails = async (book: TitleSearchResult) => {
       const result = await apiService.getAudibleMetadata<AudibleBookMetadata>(asin)
       selectedBook.value = result
       showDetailsModal.value = true
-    } catch (error) {
-      console.error('Failed to fetch detailed metadata:', error)
-      showError('Failed to fetch audiobook details. Please try again.')
+  } catch (error) {
+  console.error('Failed to fetch detailed metadata:', error)
+  toast.error('Fetch failed', 'Failed to fetch audiobook details. Please try again.')
     }
   } else {
     console.error('No ASIN available for selected book')

--- a/fe/src/views/AudiobookDetailView.vue
+++ b/fe/src/views/AudiobookDetailView.vue
@@ -427,6 +427,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, watch, computed } from 'vue'
+import { useToast } from '@/services/toastService'
 import type { Audiobook as AudiobookType } from '@/types'
 import { useRoute, useRouter } from 'vue-router'
 import { useLibraryStore } from '@/stores/library'
@@ -611,8 +612,9 @@ async function scanFiles() {
     }
   } catch (err) {
     console.error('Scan failed:', err)
-    // Show a simple alert for now
-    alert('Scan failed: ' + (err instanceof Error ? err.message : String(err)))
+    // Show a non-blocking toast instead of an alert
+    const toast = useToast()
+    toast.error('Scan failed', (err instanceof Error ? err.message : String(err)))
   } finally {
     scanning.value = false
   }

--- a/fe/src/views/DownloadsView.vue
+++ b/fe/src/views/DownloadsView.vue
@@ -112,10 +112,10 @@
 import { ref, computed, onMounted } from 'vue'
 import { useDownloadsStore } from '@/stores/downloads'
 import type { Download } from '@/types'
-import { useNotification } from '@/composables/useNotification'
+import { useToast } from '@/services/toastService'
 
 const downloadsStore = useDownloadsStore()
-const { success, error: showError, info } = useNotification()
+const toast = useToast()
 const activeTab = ref<'active' | 'completed' | 'failed'>('active')
 
 const currentDownloads = computed(() => {
@@ -138,24 +138,26 @@ const refreshDownloads = async () => {
 const cancelDownload = async (downloadId: string) => {
   try {
     await downloadsStore.cancelDownload(downloadId)
-    success('Download canceled successfully')
+    toast.success('Success', 'Download canceled successfully')
   } catch (error) {
     console.error('Failed to cancel download:', error)
-    showError('Failed to cancel download')
+    toast.error('Error', 'Failed to cancel download')
   }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const retryDownload = async (download: Download) => {
-  // For now, just show a message. In a real implementation, 
+  // For now, just show a message. In a real implementation,
   // you would restart the download
-  info('Retry functionality will be implemented soon', 'Coming Soon')
+  // useToast expects (title, message)
+  toast.info('Coming Soon', 'Retry functionality will be implemented soon')
 }
 
 const openFolder = (path: string) => {
   // This would need to be implemented with a backend endpoint
   // that can open the folder in the OS file explorer
-  info(`Would open folder: ${path}`, 'Open Folder')
+  // map (message, title) -> (title, message)
+  toast.info('Open Folder', `Would open folder: ${path}`)
 }
 
 const getEmptyMessage = () => {

--- a/fe/src/views/SearchView.vue
+++ b/fe/src/views/SearchView.vue
@@ -122,13 +122,13 @@ import { useSearchStore } from '@/stores/search'
 import { useLibraryStore } from '@/stores/library'
 import { apiService } from '@/services/api'
 import type { SearchResult, AudibleBookMetadata, QualityScore, QualityProfile } from '@/types'
-import { useNotification } from '@/composables/useNotification'
+import { useToast } from '@/services/toastService'
 import { getScoreBreakdownTooltip } from '@/composables/useScore'
 import ScorePopover from '@/components/ScorePopover.vue'
 
 const searchStore = useSearchStore()
 const libraryStore = useLibraryStore()
-const { success, error: showError, warning } = useNotification()
+const toast = useToast()
 
 console.log('SearchView component loaded')
 console.log('searchStore:', searchStore)
@@ -253,7 +253,7 @@ const addToLibrary = async (result: SearchResult) => {
   
   if (!result.asin) {
     console.warn('No ASIN available for result:', result)
-    warning('Cannot add to library: No ASIN available for this result')
+    toast.warning('Cannot add', 'Cannot add to library: No ASIN available for this result')
     return
   }
 
@@ -269,8 +269,8 @@ const addToLibrary = async (result: SearchResult) => {
     console.log('Adding to library via /api/library/add')
     await apiService.addToLibrary(metadata)
     
-    console.log('Successfully added to library')
-    success(`"${metadata.title}" has been added to your library!`)
+  console.log('Successfully added to library')
+  toast.success('Added to library', `"${metadata.title}" has been added to your library!`)
     
     // Mark this result as added
     addedResults.value.add(result.id)
@@ -279,10 +279,10 @@ const addToLibrary = async (result: SearchResult) => {
     const errorMessage = error instanceof Error ? error.message : String(error)
     
     // Check if it's a conflict (already exists)
-    if (errorMessage.includes('409') || errorMessage.includes('Conflict')) {
-      warning('This audiobook is already in your library.')
+      if (errorMessage.includes('409') || errorMessage.includes('Conflict')) {
+      toast.warning('Already exists', 'This audiobook is already in your library.')
     } else {
-      showError('Failed to add audiobook. Please try again.')
+      toast.error('Add failed', 'Failed to add audiobook. Please try again.')
     }
   } finally {
     isAddingToLibrary.value = false

--- a/listenarr.api/Controllers/ConfigurationController.cs
+++ b/listenarr.api/Controllers/ConfigurationController.cs
@@ -176,7 +176,73 @@ namespace Listenarr.Api.Controllers
         {
             try
             {
-                var id = await _configurationService.SaveDownloadClientConfigurationAsync(config);
+                if (config == null)
+                {
+                    return BadRequest("Missing download client configuration");
+                }
+                // If updating an existing configuration, avoid overwriting sensitive fields
+                // with blank values from the incoming payload. Fetch existing config
+                // and copy username/password and any client-specific apiKey when missing.
+                if (!string.IsNullOrWhiteSpace(config?.Id))
+                {
+                    var existing = await _configurationService.GetDownloadClientConfigurationAsync(config.Id);
+                    if (existing != null)
+                    {
+                        // Preserve username/password if incoming values are empty
+                        if (string.IsNullOrWhiteSpace(config.Username) && !string.IsNullOrWhiteSpace(existing.Username))
+                        {
+                            config.Username = existing.Username;
+                        }
+
+                        if (string.IsNullOrWhiteSpace(config.Password) && !string.IsNullOrWhiteSpace(existing.Password))
+                        {
+                            config.Password = existing.Password;
+                        }
+
+                        // Preserve SABnzbd API key (stored in Settings["apiKey"]) if not provided
+                        try
+                        {
+                            if (existing.Settings != null)
+                            {
+                                if (!config.Settings?.ContainsKey("apiKey") ?? true)
+                                {
+                                    if (existing.Settings.TryGetValue("apiKey", out var existingApiKeyObj))
+                                    {
+                                        var existingApiKey = existingApiKeyObj?.ToString();
+                                        if (!string.IsNullOrWhiteSpace(existingApiKey))
+                                        {
+                                            if (config.Settings == null)
+                                                config.Settings = new System.Collections.Generic.Dictionary<string, object>();
+                                            config.Settings["apiKey"] = existingApiKey;
+                                        }
+                                    }
+                                }
+                                else
+                                {
+                                    // If config.Settings contains apiKey but it's blank, preserve existing
+                                    if (config.Settings != null && config.Settings.TryGetValue("apiKey", out var incomingApiKeyObj))
+                                    {
+                                        var incomingApiKey = incomingApiKeyObj?.ToString();
+                                        if (string.IsNullOrWhiteSpace(incomingApiKey) && existing.Settings.TryGetValue("apiKey", out var exKey))
+                                        {
+                                            var existingApiKey = exKey?.ToString();
+                                            if (!string.IsNullOrWhiteSpace(existingApiKey))
+                                            {
+                                                config.Settings["apiKey"] = existingApiKey;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        catch
+                        {
+                            // Non-fatal: if Settings isn't a dictionary or unexpected structure, ignore and proceed
+                        }
+                    }
+                }
+
+                var id = await _configurationService.SaveDownloadClientConfigurationAsync(config!);
                 return Ok(new { id });
             }
             catch (Exception ex)
@@ -198,6 +264,30 @@ namespace Listenarr.Api.Controllers
             {
                 _logger.LogError(ex, "Error deleting download client configuration {Id}", id);
                 return StatusCode(500, "Internal server error");
+            }
+        }
+
+        // Test a download client configuration (accepts full config payload so credentials can be included)
+        [HttpPost("download-clients/test")]
+        public async Task<ActionResult<object>> TestDownloadClientConfiguration([FromBody] DownloadClientConfiguration config)
+        {
+            try
+            {
+                // Delegate to download service to perform protocol-specific lightweight tests
+                var downloadService = HttpContext.RequestServices.GetService(typeof(IDownloadService)) as IDownloadService;
+                if (downloadService == null)
+                {
+                    _logger.LogError("DownloadService not available to perform client test");
+                    return StatusCode(500, new { success = false, message = "Server misconfiguration: download service unavailable" });
+                }
+
+                var (Success, Message, Client) = await downloadService.TestDownloadClientAsync(config);
+                return Ok(new { success = Success, message = Message, client = Client });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error testing download client configuration");
+                return StatusCode(500, new { success = false, message = ex.Message });
             }
         }
 

--- a/listenarr.api/Program.cs
+++ b/listenarr.api/Program.cs
@@ -101,6 +101,9 @@ builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddSingleton<ILoginRateLimiter, LoginRateLimiter>();
 builder.Services.AddScoped<IDownloadProcessingQueueService, DownloadProcessingQueueService>();
 
+// Toast service for broadcasting UI toasts via SignalR
+builder.Services.AddSingleton<IToastService, ToastService>();
+
 // Always register session service, but it will check config internally
 builder.Services.AddScoped<ISessionService, ConditionalSessionService>();
 

--- a/listenarr.api/Services/IServices.cs
+++ b/listenarr.api/Services/IServices.cs
@@ -28,6 +28,9 @@ namespace Listenarr.Api.Services
         Task<string?> ReprocessDownloadAsync(string downloadId);
         Task<List<ReprocessResult>> ReprocessDownloadsAsync(List<string> downloadIds);
         Task<List<ReprocessResult>> ReprocessAllCompletedDownloadsAsync(bool includeProcessed = false, TimeSpan? maxAge = null);
+
+        // Test a download client configuration (returns success flag, message and optionally the client back)
+        Task<(bool Success, string Message, Listenarr.Api.Models.DownloadClientConfiguration? Client)> TestDownloadClientAsync(Listenarr.Api.Models.DownloadClientConfiguration client);
     }
 
     public interface IMetadataService

--- a/listenarr.api/Services/IToastService.cs
+++ b/listenarr.api/Services/IToastService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Listenarr.Api.Services
+{
+    public interface IToastService
+    {
+        Task PublishToastAsync(string level, string title, string message, int? timeoutMs = null);
+    }
+}

--- a/listenarr.api/Services/ToastService.cs
+++ b/listenarr.api/Services/ToastService.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.SignalR;
+using Listenarr.Api.Hubs;
+
+namespace Listenarr.Api.Services
+{
+    public class ToastService : IToastService
+    {
+        private readonly IHubContext<DownloadHub> _hub;
+        private readonly ILogger<ToastService> _logger;
+
+        public ToastService(IHubContext<DownloadHub> hub, ILogger<ToastService> logger)
+        {
+            _hub = hub;
+            _logger = logger;
+        }
+
+        public async Task PublishToastAsync(string level, string title, string message, int? timeoutMs = null)
+        {
+            try
+            {
+                var payload = new {
+                    level = level ?? "info",
+                    title = title ?? string.Empty,
+                    message = message ?? string.Empty,
+                    timeoutMs = timeoutMs
+                };
+
+                await _hub.Clients.All.SendAsync("ToastMessage", payload);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to publish toast message: {Title}", title);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request refactors the notification system across the frontend to use a new global toast notification mechanism for user feedback, replacing the previous modal and inline notification approach. It introduces a reusable `GlobalToast` component, updates all relevant components to use the new toast service, and adds support for server-sent toast messages via SignalR. The changes improve consistency, user experience, and maintainability of notifications throughout the application.

**Global Toast Notification System**
* Added new `GlobalToast.vue` component for displaying toast notifications globally, with support for info, success, warning, and error styles and smooth transitions.
* Introduced `useToast` composable service and refactored all components to use it instead of the legacy `useNotification` or modal alerts, ensuring a consistent notification API. [[1]](diffhunk://#diff-f0c043db1f7b55e12f18cac1ed6f94e7ddfd336d3216607cb032ae289989769eL149-R149) [[2]](diffhunk://#diff-d742ebd44b2bec6b497f377fbf00706b2152eb660e886d37c7ae571f819e4fe6L155-R155) [[3]](diffhunk://#diff-697353b1801136330b8e72f5fa6879f4c09d8a42b079d3ec1af1d523ed4f55fbL290-R290) [[4]](diffhunk://#diff-9974d4d5c81ee460d8ce855ef609e71c11902e85e83cb00c9ad513846df85ee5L260-R260) [[5]](diffhunk://#diff-f0308f48287e9d0e2feb83c36081b369c191746862392201a69cd118ec42541cR185) [[6]](diffhunk://#diff-5f9087d5945c32ecd042f10cb293a2bce0f0ee36ac4999e110830da2cbfe5f06R583-R600) [[7]](diffhunk://#diff-9d4fc96ccd70992e244b9d7db58e24f8a8ad8e221fe1ec5b933bba3678cc1c0dR101)

**Component Refactoring**
* Updated all major modals (`AddLibraryModal`, `BulkEditModal`, `DownloadClientFormModal`, `EditAudiobookModal`, `IndexerFormModal`, `ManualSearchModal`, `QualityProfileFormModal`) to use toast notifications for success, error, and validation feedback, replacing alerts and inline notifications. [[1]](diffhunk://#diff-f0c043db1f7b55e12f18cac1ed6f94e7ddfd336d3216607cb032ae289989769eL197-R203) [[2]](diffhunk://#diff-d742ebd44b2bec6b497f377fbf00706b2152eb660e886d37c7ae571f819e4fe6L274-R274) [[3]](diffhunk://#diff-697353b1801136330b8e72f5fa6879f4c09d8a42b079d3ec1af1d523ed4f55fbL431-R434) [[4]](diffhunk://#diff-9974d4d5c81ee460d8ce855ef609e71c11902e85e83cb00c9ad513846df85ee5L387-R401) [[5]](diffhunk://#diff-f0308f48287e9d0e2feb83c36081b369c191746862392201a69cd118ec42541cL485-R488) [[6]](diffhunk://#diff-5f9087d5945c32ecd042f10cb293a2bce0f0ee36ac4999e110830da2cbfe5f06R583-R600) [[7]](diffhunk://#diff-9d4fc96ccd70992e244b9d7db58e24f8a8ad8e221fe1ec5b933bba3678cc1c0dL186-R188)

**SignalR Integration**
* Added support for server-sent toast messages in SignalR: the frontend now listens for toast events and forwards them to the toast service for display, enabling real-time notifications from the backend. [[1]](diffhunk://#diff-d9dbc25646643482273724d4518664df234094cb979d142609ce842808083911R507-R520) [[2]](diffhunk://#diff-aa8bbdbccdcf63d4df79b60c849760ccf1ba010d51eeff3977389268a3a17ee0R31)

**API Enhancements**
* Added new API endpoint and helper for testing download client configurations, supporting toast-based feedback for test results. [[1]](diffhunk://#diff-d32610bbe3f6b6917264f715b7a3149fd8b7dd4fb0eacbb494ca31b9b91f5719R306-R313) [[2]](diffhunk://#diff-d32610bbe3f6b6917264f715b7a3149fd8b7dd4fb0eacbb494ca31b9b91f5719R805-R807)

**App Integration**
* Registered the `GlobalToast` component in the main app template so toasts are visible on all pages, and refactored notification logic in `App.vue` to use the new toast service. [[1]](diffhunk://#diff-d9dbc25646643482273724d4518664df234094cb979d142609ce842808083911R180-R182) [[2]](diffhunk://#diff-d9dbc25646643482273724d4518664df234094cb979d142609ce842808083911R198-R201) [[3]](diffhunk://#diff-d9dbc25646643482273724d4518664df234094cb979d142609ce842808083911R483-R491)

These changes collectively modernize the notification UX and simplify notification management throughout the frontend.