### PR TITLE
Remove CORS attribute from AudibleController

### DIFF
--- a/listenarr.api/Controllers/AudibleController.cs
+++ b/listenarr.api/Controllers/AudibleController.cs
@@ -28,7 +28,6 @@ namespace Listenarr.Api.Controllers
 {
     [ApiController]
     [Route("api/audible")]
-    [EnableCors("AllowVueApp")]
     public class AudibleController : ControllerBase
     {
         private readonly IAudibleMetadataService _audibleMetadataService;


### PR DESCRIPTION
This pull request makes a minor change to the `AudibleController` in the API by removing the CORS policy attribute. This simplifies the controller setup and may affect how cross-origin requests are handled for this endpoint.