### PR TITLE
Update .NET restore command in CI workflows

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -52,7 +52,7 @@ jobs:
           echo "VERSION=${NEWVERSION}" >> $GITHUB_OUTPUT
 
       - name: Restore .NET
-        run: dotnet restore ${{ env.API_PROJECT }}
+        run: dotnet restore listenarr.sln
 
       - name: Persist bumped version to csproj (for build)
         if: steps.resolve-version.outputs.VERSION != ''

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,7 +52,7 @@ jobs:
           echo "VERSION=${NEWVERSION}" >> $GITHUB_OUTPUT
 
       - name: Restore .NET
-        run: dotnet restore ${{ env.API_PROJECT }}
+        run: dotnet restore listenarr.sln
 
       - name: Persist bumped version to csproj (for build)
         if: steps.resolve-version.outputs.VERSION != ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           echo "VERSION=${NEWVERSION}" >> $GITHUB_OUTPUT
 
       - name: Restore .NET
-        run: dotnet restore ${{ env.API_PROJECT }}
+        run: dotnet restore listenarr.sln
 
       - name: Persist bumped version to csproj (for build)
         if: steps.resolve-version.outputs.VERSION != ''


### PR DESCRIPTION
This pull request makes a small but important update to the workflow configuration for building the .NET project. The change ensures that the correct solution file is restored during the build process for all workflows.

* Updated the `.NET restore` step in `.github/workflows/canary.yml`, `.github/workflows/nightly.yml`, and `.github/workflows/release.yml` to use `listenarr.sln` instead of the environment variable `${{ env.API_PROJECT }}`. [[1]](diffhunk://#diff-4b56c7c159ef6d182d11a4f6d189ea69d9ee8b2dfde7e7e920052190549c65e8L55-R55) [[2]](diffhunk://#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6L55-R55) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L49-R49)