### PR TITLE
Refactor base directory computation and improve manual import path

### DIFF
--- a/tests/Listenarr.Api.Tests/LibraryController_BasePathTests.cs
+++ b/tests/Listenarr.Api.Tests/LibraryController_BasePathTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Listenarr.Api.Controllers;
+using Listenarr.Api.Models;
+using Listenarr.Api.Services;
+using System.IO;
+
+namespace Listenarr.Api.Tests
+{
+    public class LibraryController_BasePathTests
+    {
+        [Fact]
+        public void ComputeAudiobookBaseDirectoryFromPattern_NonSeriesBook_ReturnsCorrectPath()
+        {
+            // Arrange
+            var audiobook = new Audiobook
+            {
+                Title = "The Buffalo Hunter Hunter",
+                Authors = new List<string> { "Stephen Graham Jones" },
+                PublishYear = "2025",
+                Series = null, // No series
+                SeriesNumber = null
+            };
+
+            var rootPath = "/server/mnt/drive/Audiobooks";
+            var fileNamingPattern = "{Author}/{Title} ({Year})"; // This shouldn't matter for directory creation
+
+            // Mock dependencies
+            var mockRepo = new Mock<IAudiobookRepository>();
+            var mockImageCache = new Mock<IImageCacheService>();
+            var mockLogger = new Mock<ILogger<LibraryController>>();
+            var mockScanQueue = new Mock<IScanQueueService>();
+
+            var options = new DbContextOptionsBuilder<ListenArrDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            var dbContext = new ListenArrDbContext(options);
+
+            var mockFileNamingService = new Mock<IFileNamingService>();
+            mockFileNamingService
+                .Setup(x => x.ApplyNamingPattern(It.IsAny<string>(), It.IsAny<Dictionary<string, object>>(), false))
+                .Returns((string pattern, Dictionary<string, object> vars, bool sanitize) =>
+                {
+                    // For the non-series book test, the pattern should be derived from "{Author}/{Title} ({Year})"
+                    // which becomes "{Author}/{Title} ({Year})" (no change since no file-specific vars)
+                    if (pattern == "{Author}/{Title} ({Year})")
+                    {
+                        return $"Stephen Graham Jones/The Buffalo Hunter Hunter (2025)";
+                    }
+                    return pattern;
+                });
+
+            var serviceProvider = new Mock<IServiceProvider>();
+
+            // Create controller instance
+            var controller = new LibraryController(
+                mockRepo.Object,
+                mockImageCache.Object,
+                mockLogger.Object,
+                dbContext,
+                serviceProvider.Object,
+                mockFileNamingService.Object,
+                mockScanQueue.Object);
+
+            // Get the private method using reflection
+            var method = typeof(LibraryController).GetMethod("ComputeAudiobookBaseDirectoryFromPattern",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+
+            // Act
+            var result = (string)method.Invoke(controller, new object[] { audiobook, rootPath, fileNamingPattern });
+
+            // Assert
+            var expected = Path.Combine("/server/mnt/drive/Audiobooks", "Stephen Graham Jones/The Buffalo Hunter Hunter (2025)");
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void ComputeAudiobookBaseDirectoryFromPattern_SeriesBook_ReturnsCorrectPath()
+        {
+            // Arrange
+            var audiobook = new Audiobook
+            {
+                Title = "The Gunslinger",
+                Authors = new List<string> { "Stephen King" },
+                PublishYear = "1982",
+                Series = "The Dark Tower",
+                SeriesNumber = "1"
+            };
+
+            var rootPath = "/server/mnt/drive/Audiobooks";
+            var fileNamingPattern = "{Author}/{Series}/{Title} ({Year})"; // This shouldn't matter for directory creation
+
+            // Mock dependencies
+            var mockRepo = new Mock<IAudiobookRepository>();
+            var mockImageCache = new Mock<IImageCacheService>();
+            var mockLogger = new Mock<ILogger<LibraryController>>();
+            var mockScanQueue = new Mock<IScanQueueService>();
+
+            var options = new DbContextOptionsBuilder<ListenArrDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            var dbContext = new ListenArrDbContext(options);
+
+            var mockFileNamingService = new Mock<IFileNamingService>();
+            mockFileNamingService
+                .Setup(x => x.ApplyNamingPattern(It.IsAny<string>(), It.IsAny<Dictionary<string, object>>(), false))
+                .Returns((string pattern, Dictionary<string, object> vars, bool sanitize) =>
+                {
+                    // For the series book test, the pattern should be derived from "{Author}/{Series}/{Title} ({Year})"
+                    // which becomes "{Author}/{Series}/{Title} ({Year})" (no change since no file-specific vars)
+                    if (pattern == "{Author}/{Series}/{Title} ({Year})")
+                    {
+                        return $"Stephen King/The Dark Tower/The Gunslinger (1982)";
+                    }
+                    return pattern;
+                });
+
+            var serviceProvider = new Mock<IServiceProvider>();
+
+            // Create controller instance
+            var controller = new LibraryController(
+                mockRepo.Object,
+                mockImageCache.Object,
+                mockLogger.Object,
+                dbContext,
+                serviceProvider.Object,
+                mockFileNamingService.Object,
+                mockScanQueue.Object);
+
+            // Get the private method using reflection
+            var method = typeof(LibraryController).GetMethod("ComputeAudiobookBaseDirectoryFromPattern",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+
+            // Act
+            var result = (string)method.Invoke(controller, new object[] { audiobook, rootPath, fileNamingPattern });
+
+            // Assert
+            var expected = Path.Combine("/server/mnt/drive/Audiobooks", "Stephen King/The Dark Tower/The Gunslinger (1982)");
+            Assert.Equal(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
This pull request refactors how audiobook base directories and manual import paths are computed, making directory structure generation more predictable and testable. The changes focus on improving the handling of file naming patterns for both regular and manual imports, and add tests to ensure correctness.

**Directory and Path Computation Improvements:**

* Refactored `ComputeAudiobookBaseDirectoryFromPattern` to strip file-specific variables (like `{DiskNumber}` and `{ChapterNumber}`) from the naming pattern, ensuring only directory-level metadata is used to build the base path. The method now combines the cleaned pattern with the root path and returns the full directory path, rather than extracting a directory from a file path. [[1]](diffhunk://#diff-d31edde6e4a0c9124203b0d65cb118bb9991f4b7957dfcdf94671a41cac88735R1339-R1355) [[2]](diffhunk://#diff-d31edde6e4a0c9124203b0d65cb118bb9991f4b7957dfcdf94671a41cac88735L1351-R1375)
* Updated manual import path generation in `GenerateManualImportPathAsync` to use a simplified directory pattern (`{Series}/{Title}` or `{Title}`) and to always include the correct file extension. The result is a full path combining the audiobook's base path and the generated relative path. [[1]](diffhunk://#diff-f77b49a3fcd415f5537dcb69164e7d4c4017adecec41880ad7edadbf998943f8L239-R240) [[2]](diffhunk://#diff-f77b49a3fcd415f5537dcb69164e7d4c4017adecec41880ad7edadbf998943f8L249-R285)

**Testing Enhancements:**

* Added a new test file `LibraryController_BasePathTests.cs` with unit tests for `ComputeAudiobookBaseDirectoryFromPattern`, verifying correct directory paths for both series and non-series audiobooks.

**General Codebase Improvements:**

* Added `System.Text.RegularExpressions` import to support pattern cleaning in directory computation.