### PR TITLE
Implement cross-tab session token sync and logout

### DIFF
--- a/fe/src/__tests__/sessionTokenStorage.test.ts
+++ b/fe/src/__tests__/sessionTokenStorage.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { sessionTokenManager } from '@/utils/sessionToken'
+
+describe('sessionTokenManager storage propagation', () => {
+  beforeEach(() => {
+    // Ensure clean localStorage before each test
+    try { localStorage.removeItem('listenarr_session_token') } catch {}
+  })
+
+  afterEach(() => {
+    try { localStorage.removeItem('listenarr_session_token') } catch {}
+  })
+
+  it('notifies subscribers when storage is changed (cross-tab)', () => {
+    const events: Array<string | null> = []
+    const unsub = sessionTokenManager.onTokenChange((token) => { events.push(token) })
+
+    // Simulate another tab writing to localStorage by dispatching a StorageEvent
+    const token = 'abc123'
+    // Manually set localStorage (emulating other tab)
+    localStorage.setItem('listenarr_session_token', token)
+    // Emit storage event
+    const ev = new StorageEvent('storage', { key: 'listenarr_session_token', newValue: token })
+    window.dispatchEvent(ev)
+
+    expect(events.length).toBeGreaterThanOrEqual(1)
+    expect(events[events.length - 1]).toBe(token)
+
+    // Now simulate removal
+    localStorage.removeItem('listenarr_session_token')
+    const ev2 = new StorageEvent('storage', { key: 'listenarr_session_token', newValue: null })
+    window.dispatchEvent(ev2)
+
+    expect(events[events.length - 1]).toBe(null)
+
+    unsub()
+  })
+})

--- a/fe/src/utils/sessionToken.ts
+++ b/fe/src/utils/sessionToken.ts
@@ -5,9 +5,14 @@
 class SessionTokenManager {
   private static readonly STORAGE_KEY = 'listenarr_session_token'
   private token: string | null = null
+  private subscribers: Set<(token: string | null) => void> = new Set()
 
   constructor() {
     this.loadFromStorage()
+    // Listen for storage events from other tabs/windows
+    if (typeof window !== 'undefined' && window.addEventListener) {
+      window.addEventListener('storage', this.handleStorageEvent)
+    }
   }
 
   private loadFromStorage(): void {
@@ -33,6 +38,10 @@ class SessionTokenManager {
     } catch {
       // Storage might be unavailable
     }
+    // Notify subscribers synchronously
+    try {
+      for (const cb of Array.from(this.subscribers)) cb(this.token)
+    } catch {}
   }
 
   clearToken(): void {
@@ -41,6 +50,33 @@ class SessionTokenManager {
 
   hasToken(): boolean {
     return !!this.token
+  }
+
+  // Subscribe to token changes (including cross-tab storage events)
+  onTokenChange(cb: (token: string | null) => void): () => void {
+    this.subscribers.add(cb)
+    // Call immediately with current value so subscribers have initial state
+    try { cb(this.token) } catch {}
+    return () => { this.subscribers.delete(cb) }
+  }
+
+  private handleStorageEvent = (ev: StorageEvent) => {
+    try {
+      if (!ev) return
+      if (ev.key !== SessionTokenManager.STORAGE_KEY) return
+
+      // If newValue is null, token was removed in another tab; update internal
+      // token value and notify subscribers.
+      try {
+        this.token = ev.newValue
+      } catch {
+        this.token = null
+      }
+
+      for (const cb of Array.from(this.subscribers)) {
+        try { cb(this.token) } catch {}
+      }
+    } catch {}
   }
 }
 

--- a/fe/src/views/SettingsView.vue
+++ b/fe/src/views/SettingsView.vue
@@ -942,6 +942,20 @@ const indexerToDelete = ref<Indexer | null>(null)
 const profileToDelete = ref<QualityProfile | null>(null)
 const adminUsers = ref<Array<{ id: number; username: string; email?: string; isAdmin: boolean; createdAt: string }>>([])
   const showPassword = ref(false)
+
+  // Expose a toggle function for unit tests and template interactions that
+  // prefer a method instead of inline assignment. Tests call
+  // `wrapper.vm.toggleShowPassword()` so we expose it here.
+  const toggleShowPassword = () => {
+    showPassword.value = !showPassword.value
+  }
+
+  // Make the function available on the component instance for Vue Test Utils
+  // and any external consumers that expect an instance method.
+  // `defineExpose` is a compiler macro available in <script setup>.
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  defineExpose({ toggleShowPassword })
 const showMappingForm = ref(false)
 const mappingToEdit = ref<RemotePathMapping | null>(null)
 


### PR DESCRIPTION
This pull request introduces important improvements to authentication handling and session management in the frontend. The main changes ensure that API keys are only used when server authentication is disabled, implement robust cross-tab logout so users are logged out everywhere when their session ends, and add new utilities and tests to support these features.

**Authentication and API Key Handling**
* Updated both `apiService` and `SignalRService` to only attach the API key to requests if server authentication is disabled, preventing accidental bypassing of login/logout flows. This is determined by checking both camelCase and PascalCase variants of the `authenticationRequired` flag for compatibility. [[1]](diffhunk://#diff-d32610bbe3f6b6917264f715b7a3149fd8b7dd4fb0eacbb494ca31b9b91f5719L57-R70) [[2]](diffhunk://#diff-aa8bbdbccdcf63d4df79b60c849760ccf1ba010d51eeff3977389268a3a17ee0L47-R58)

**Cross-tab Session Management**
* Enhanced `sessionTokenManager` in `sessionToken.ts` to support subscriber notifications on token changes, including handling storage events for cross-tab logout. Added the `onTokenChange` method and event handler for storage changes. [[1]](diffhunk://#diff-ee0a320556ce79a2dac731a4be17bb9ac1e705e839ce258570e25622a0814386R8-R15) [[2]](diffhunk://#diff-ee0a320556ce79a2dac731a4be17bb9ac1e705e839ce258570e25622a0814386R41-R44) [[3]](diffhunk://#diff-ee0a320556ce79a2dac731a4be17bb9ac1e705e839ce258570e25622a0814386R54-R80)
* Updated `auth.ts` store to react to token removals in other tabs by clearing user state and navigating to the login page, ensuring consistent logout across all open tabs. Also added comprehensive client-side cleanup during logout. [[1]](diffhunk://#diff-65094827a39c743a622d913ff5aeab3878476dcf955f1da819d35bf595c54875R42-R70) [[2]](diffhunk://#diff-65094827a39c743a622d913ff5aeab3878476dcf955f1da819d35bf595c54875R80-R95)

**Testing and Utilities**
* Added a new unit test in `sessionTokenStorage.test.ts` to verify that subscribers are notified of session token changes, including cross-tab scenarios.
* Exposed a `toggleShowPassword` method in `SettingsView.vue` for improved testability and template interaction.