### PR TITLE
Bump version to 0.2.11

### DIFF
--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -4,14 +4,14 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     
-    <Version>0.2.10</Version>
-    <AssemblyVersion>0.2.10</AssemblyVersion>
+    <Version>0.2.11</Version>
+    <AssemblyVersion>0.2.11</AssemblyVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  <!-- Suppress missing XML comment warnings in public API to reduce noise during CI/dev builds -->
+  
   <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR bumps the application version to 0.2.11.
The change was produced automatically by the CI canary workflow.