### PR TITLE
Use session token for image URLs if available

### DIFF
--- a/fe/src/App.vue
+++ b/fe/src/App.vue
@@ -35,7 +35,7 @@
             <ul v-if="suggestions.length > 0" class="search-list">
               <li v-for="s in suggestions" :key="s.id" class="search-result" @click="selectSuggestion(s)">
                 <div style="display:flex;align-items:center;gap:10px;">
-                  <img v-if="s.imageUrl" :src="s.imageUrl" alt="cover" class="result-thumb" />
+                  <img v-if="s.imageUrl" :src="apiService.getImageUrl(s.imageUrl)" alt="cover" class="result-thumb" />
                   <div>
                     <div class="result-title">{{ s.title }}</div>
                     <div class="result-sub">{{ s.author }}</div>

--- a/fe/src/components/AudiobookDetailsModal.vue
+++ b/fe/src/components/AudiobookDetailsModal.vue
@@ -12,7 +12,7 @@
         <div class="book-layout">
           <!-- Book Image -->
           <div class="book-image">
-            <img v-if="book.imageUrl" :src="book.imageUrl" :alt="book.title" />
+            <img v-if="book.imageUrl" :src="apiService.getImageUrl(book.imageUrl)" :alt="book.title" />
             <div v-else class="placeholder-cover">
               <i class="ph ph-image"></i>
               <span>No Cover</span>
@@ -151,7 +151,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import type { AudibleBookMetadata, QualityProfile } from '@/types'
-import { getQualityProfiles } from '@/services/api'
+import { getQualityProfiles, apiService } from '@/services/api'
 
 interface Props {
   visible: boolean


### PR DESCRIPTION
This pull request improves how image URLs are generated and handled throughout the frontend, ensuring that authentication is properly applied when fetching images. The main change is the addition of logic to prefer a session token (for authenticated users) when constructing image URLs, with a fallback to the API key for unauthenticated access. This update helps secure image access and supports user-specific sessions.

**Image URL handling and authentication:**

* Updated the `ApiService.getImageUrl` method in `fe/src/services/api.ts` to append a session token to image URLs if available, falling back to the API key if not. This applies to both library-detected and other relative image URLs, ensuring authenticated access where possible.
* Refactored image rendering in `fe/src/App.vue` and `fe/src/components/AudiobookDetailsModal.vue` to use the new `apiService.getImageUrl` method, ensuring that all image requests benefit from the improved authentication logic. [[1]](diffhunk://#diff-d9dbc25646643482273724d4518664df234094cb979d142609ce842808083911L38-R38) [[2]](diffhunk://#diff-4687291423da5d01e8995e51351d922329d849f46adb7cdab7e62304c7af38aeL15-R15)
* Imported `apiService` into `AudiobookDetailsModal.vue` to support the new usage of the image URL helper.Updated image URL generation to prefer session tokens for authenticated users, falling back to API key for non-authenticated access. Refactored image rendering in App.vue and AudiobookDetailsModal.vue to use the new apiService.getImageUrl method for consistent access control.