### PR TITLE
Use apiService for cover image URLs

### DIFF
--- a/fe/src/views/AddNewView.vue
+++ b/fe/src/views/AddNewView.vue
@@ -734,7 +734,7 @@ const loadMoreTitleResults = async () => {
 const getCoverUrl = (book: TitleSearchResult): string => {
   // Check for audimeta result image URL first
   if (book.imageUrl) {
-    return book.imageUrl
+    return apiService.getImageUrl(book.imageUrl)
   }
   // Fall back to search result image URL
   const imageUrl = book.searchResult?.imageUrl || ''


### PR DESCRIPTION
This pull request introduces a small change to the way cover image URLs are handled in the `AddNewView.vue` file. The update ensures that image URLs are consistently processed through the `apiService.getImageUrl` method before being returned.

* Cover image URLs are now passed through `apiService.getImageUrl` instead of being returned directly, ensuring consistent formatting and handling for all book images.Updated getCoverUrl to use apiService.getImageUrl for book.imageUrl, ensuring consistent image URL formatting and handling.