### PR TITLE
Cache images in background without changing search result URLs

### DIFF
--- a/listenarr.api/Services/SearchService.cs
+++ b/listenarr.api/Services/SearchService.cs
@@ -955,23 +955,20 @@ namespace Listenarr.Api.Services
                 imageUrl = fallbackImageUrl;
             }
             
-            // Download and cache the image to temp storage
+            // Download and cache the image to temp storage for future use
+            // Keep the original external URL for search results to avoid 404s
             if (!string.IsNullOrEmpty(imageUrl) && !string.IsNullOrEmpty(asin))
             {
                 try
                 {
-                    var cachedPath = await _imageCacheService.DownloadAndCacheImageAsync(imageUrl, asin);
-                    if (cachedPath != null)
-                    {
-                        // Return API endpoint URL instead of file path
-                        imageUrl = $"/api/images/{asin}";
-                        _logger.LogInformation("Cached image for ASIN {Asin} to temp storage, API URL: {ImageUrl}", asin, imageUrl);
-                    }
+                    // Cache the image in background, but don't wait for it or change the URL
+                    // This ensures search results always show images immediately from their source
+                    _ = _imageCacheService.DownloadAndCacheImageAsync(imageUrl, asin);
+                    _logger.LogDebug("Started background image cache for ASIN {Asin}", asin);
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning(ex, "Failed to cache image for ASIN {Asin}, will use remote URL", asin);
-                    // Keep the original remote URL if caching fails
+                    _logger.LogWarning(ex, "Failed to initiate image caching for ASIN {Asin}", asin);
                 }
             }
             


### PR DESCRIPTION
This pull request updates the image caching behavior in the `SearchService` to improve reliability and user experience for search results. Instead of waiting for images to be cached before displaying them, the service now always uses the original external image URLs, caching images in the background for future use.

Improvements to image caching and search result reliability:

* Changed the image caching logic in `ConvertMetadataToSearchResultAsync` so that search results always use the original external image URL, avoiding potential 404s or delays. Image caching is now initiated in the background, ensuring faster and more reliable search result rendering. (`listenarr.api/Services/SearchService.cs`)Images are now cached asynchronously in the background to improve future performance, but search results continue to use the original external image URLs to avoid potential 404 errors. Logging has been updated to reflect the new caching behavior.