### PR TITLE
Fixing missed migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.22] - 2025-11-08
+
+### Fixed
+- **Database migration: Discord settings**: add missing Discord-related columns to `ApplicationSettings` to avoid runtime SQLite errors when upgrading older databases
+  - Adds `DiscordApplicationId`, `DiscordBotAvatar`, `DiscordBotEnabled`, `DiscordBotToken`, `DiscordBotUsername`, `DiscordChannelId`, `DiscordCommandGroupName`, `DiscordCommandSubcommandName`, and `DiscordGuildId`
+- **Backend: warning cleanup**: silence CS1998 compiler warnings in `DiscordBotService` by returning completed tasks for synchronous methods (StopBotAsync, IsBotRunningAsync)
+
 ## [0.2.21] - 2025-11-08
 
 ### Added

--- a/listenarr.api/Migrations/20251108121500_AddDiscordSettingsToApplicationSettings.cs
+++ b/listenarr.api/Migrations/20251108121500_AddDiscordSettingsToApplicationSettings.cs
@@ -1,0 +1,109 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Listenarr.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDiscordSettingsToApplicationSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DiscordApplicationId",
+                table: "ApplicationSettings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DiscordBotAvatar",
+                table: "ApplicationSettings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "DiscordBotEnabled",
+                table: "ApplicationSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DiscordBotToken",
+                table: "ApplicationSettings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DiscordBotUsername",
+                table: "ApplicationSettings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DiscordChannelId",
+                table: "ApplicationSettings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DiscordCommandGroupName",
+                table: "ApplicationSettings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DiscordCommandSubcommandName",
+                table: "ApplicationSettings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DiscordGuildId",
+                table: "ApplicationSettings",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DiscordGuildId",
+                table: "ApplicationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "DiscordCommandSubcommandName",
+                table: "ApplicationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "DiscordCommandGroupName",
+                table: "ApplicationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "DiscordChannelId",
+                table: "ApplicationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "DiscordBotUsername",
+                table: "ApplicationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "DiscordBotToken",
+                table: "ApplicationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "DiscordBotEnabled",
+                table: "ApplicationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "DiscordBotAvatar",
+                table: "ApplicationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "DiscordApplicationId",
+                table: "ApplicationSettings");
+        }
+    }
+}

--- a/listenarr.api/Services/DiscordBotService.cs
+++ b/listenarr.api/Services/DiscordBotService.cs
@@ -100,14 +100,14 @@ namespace Listenarr.Api.Services
             }
         }
 
-        public async Task<bool> StopBotAsync()
+        public Task<bool> StopBotAsync()
         {
             lock (_processLock)
             {
                 if (_botProcess == null || _botProcess.HasExited)
                 {
                     _logger.LogInformation("Bot is not running");
-                    return true;
+                    return Task.FromResult(true);
                 }
 
                 try
@@ -116,21 +116,21 @@ namespace Listenarr.Api.Services
                     _botProcess.Kill(true); // Kill entire process tree
                     _botProcess.WaitForExit(5000); // Wait up to 5 seconds
                     _botProcess = null;
-                    return true;
+                    return Task.FromResult(true);
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to stop Discord bot");
-                    return false;
+                    return Task.FromResult(false);
                 }
             }
         }
 
-        public async Task<bool> IsBotRunningAsync()
+        public Task<bool> IsBotRunningAsync()
         {
             lock (_processLock)
             {
-                return _botProcess != null && !_botProcess.HasExited;
+                return Task.FromResult(_botProcess != null && !_botProcess.HasExited);
             }
         }
 


### PR DESCRIPTION
This pull request addresses issues with Discord bot integration by updating the database schema and cleaning up backend warnings. The most important changes include adding missing Discord-related columns to the `ApplicationSettings` table to prevent SQLite migration errors, and silencing compiler warnings in `DiscordBotService` by making certain async methods return completed tasks.

**Database migration improvements:**

* Added migration `20251108121500_AddDiscordSettingsToApplicationSettings.cs` to add Discord-related columns (`DiscordApplicationId`, `DiscordBotAvatar`, `DiscordBotEnabled`, `DiscordBotToken`, `DiscordBotUsername`, `DiscordChannelId`, `DiscordCommandGroupName`, `DiscordCommandSubcommandName`, `DiscordGuildId`) to the `ApplicationSettings` table, ensuring compatibility with older databases and preventing runtime SQLite errors.

**Backend warning cleanup:**

* Updated `DiscordBotService.cs` to silence CS1998 compiler warnings by making `StopBotAsync` and `IsBotRunningAsync` return `Task.FromResult(...)` instead of being marked `async` without any awaits. This ensures proper async method signatures without unnecessary warnings. [[1]](diffhunk://#diff-18d919cc3424e7e57a168c852b80167491f7fa2719b88c35bd0dda861a93dadbL103-R110) [[2]](diffhunk://#diff-18d919cc3424e7e57a168c852b80167491f7fa2719b88c35bd0dda861a93dadbL119-R133)

**Documentation:**

* Added a changelog entry for version 0.2.22 documenting the database migration and backend warning cleanup.Introduces new migration to add Discord-related configuration fields to the ApplicationSettings table. Refactors DiscordBotService methods StopBotAsync and IsBotRunningAsync to return Task<bool> synchronously instead of using async/await.