### PR TITLE
Bump version to 0.2.25

### DIFF
--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -4,8 +4,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     
-    <Version>0.2.24</Version>
-    <AssemblyVersion>0.2.24</AssemblyVersion>
+    <Version>0.2.25</Version>
+    <AssemblyVersion>0.2.25</AssemblyVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
@@ -98,7 +98,7 @@
     <None Remove="config\config.json" />
   </ItemGroup>
 
-  <!-- Include tools directory in publish for Discord bot -->
+  
   <ItemGroup>
     <Content Include="tools\**\*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
This PR bumps the application version to 0.2.25.
The change was produced automatically by the CI canary workflow.