### PR TITLE
Add fail-fast checks for tools folder in CI workflows

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -331,6 +331,45 @@ jobs:
           dotnet publish listenarr.api/Listenarr.Api.csproj -c Release -o listenarr.api/publish
         # Ensures Listenarr.Api.dll is at listenarr.api/publish/ for Dockerfile.runtime
 
+      - name: Show publish contents (sanity check)
+        run: |
+          echo "Listing publish folder contents"
+          ls -la listenarr.api/publish || true
+          echo "Listing publish/tools contents"
+          ls -la listenarr.api/publish/tools || echo "publish/tools missing"
+
+      - name: Fail if tools missing in publish (quick fail)
+        run: |
+          if [ ! -d "listenarr.api/publish/tools" ]; then
+            echo "ERROR: listenarr.api/publish/tools is missing after publish. Aborting build to avoid pushing a broken image."
+            ls -la listenarr.api/publish || true
+            exit 1
+          fi
+          echo "publish/tools present"
+
+      - name: Upload publish folder (debug artifact)
+        uses: actions/upload-artifact@v4
+        with:
+          name: listenarr-publish-folder
+          path: listenarr.api/publish
+
+      - name: Copy tools into publish and verify
+        run: |
+          echo "Ensuring tools are present in listenarr.api/publish"
+          if [ ! -d "listenarr.api/publish/tools" ]; then
+            echo "publish/tools missing — copying from repo"
+            cp -r tools listenarr.api/publish/
+          else
+            echo "publish/tools already present"
+          fi
+          echo "Verifying publish/tools exists"
+          if [ ! -d "listenarr.api/publish/tools" ]; then
+            echo "ERROR: publish/tools missing after copy"
+            ls -la listenarr.api/publish || true
+            exit 1
+          fi
+          ls -la listenarr.api/publish/tools
+
       - name: Build and push API image (canary + sha)
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,26 @@ jobs:
         working-directory: ./listenarr.api
         run: dotnet publish Listenarr.Api.csproj -c Release -r linux-x64 --no-self-contained -o ./publish/linux-x64
 
+      - name: Fail if tools missing in publish (quick fail)
+        run: |
+          echo "Checking publish locations for tools folder"
+          # CI publishes into listenarr.api/publish/linux-x64 (relative to repo root)
+          if [ -d "listenarr.api/publish/linux-x64/tools" ]; then
+            echo "Found tools in listenarr.api/publish/linux-x64/tools"
+            ls -la listenarr.api/publish/linux-x64/tools || true
+          elif [ -d "listenarr.api/publish/tools" ]; then
+            echo "Found tools in listenarr.api/publish/tools"
+            ls -la listenarr.api/publish/tools || true
+          elif [ -d "listenarr.api/publish/linux-x64/publish/tools" ]; then
+            echo "Found tools in nested listenarr.api/publish/linux-x64/publish/tools"
+            ls -la listenarr.api/publish/linux-x64/publish/tools || true
+          else
+            echo "ERROR: tools folder not found in publish outputs. Listing publish directories for debugging:"
+            ls -la listenarr.api/publish || true
+            ls -la listenarr.api/publish/linux-x64 || true
+            exit 1
+          fi
+
       - name: Upload API artifact
         uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - **Publish: include tools folder**: Ensured `tools/**` is copied to the publish output by updating `Listenarr.Api.csproj` (added <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory> for `tools\**\*.*`)
    - Fixes missing `/app/tools/discord-bot` inside runtime containers when publishing + copying publish output into images
    - After this change, run `dotnet publish` and rebuild your image so the tooling directory is included in the container
+  - **CI: fail-fast & publish verification**: Added quick-fail checks and publish-folder verification to CI and Canary workflows so builds abort if the `tools` folder is missing from publish output
+    - Canary workflow now lists the publish folder, uploads the publish artifact for inspection, and contains a copy-then-verify step that will copy `tools` into the publish folder if CIS publish missed them
+    - Main CI workflow now performs a fail-fast check after `dotnet publish` to avoid building/pushing images that don't include the discord helper files
+    - These steps reduce the risk of releasing runtime images that cannot start the Discord helper bot
 
 ## [0.2.25] - 2025-11-09
 

--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -107,4 +107,14 @@
     </Content>
   </ItemGroup>
 
+  <!-- Explicit fallback: copy tools into publish output to ensure runtime images get them -->
+  <Target Name="CopyToolsToPublish" AfterTargets="Publish">
+    <Message Importance="high" Text="Copying tools folder to publish folder ($(PublishDir)tools)" />
+    <ItemGroup>
+      <ToolFiles Include="$(MSBuildProjectDirectory)\tools\**\*.*" />
+    </ItemGroup>
+    <MakeDir Directories="$(PublishDir)tools" Condition="!Exists('$(PublishDir)tools')" />
+    <Copy SourceFiles="@(ToolFiles)" DestinationFiles="@(ToolFiles->'$(PublishDir)tools\\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="false" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
This pull request improves the reliability of the build and release process by ensuring the `tools` folder is always present in the publish output, preventing broken runtime images. It adds fail-fast checks and verification steps to both CI and Canary workflows, updates the publish logic in the project file, and documents these changes in the changelog.

**CI/CD workflow improvements:**

* Added fail-fast checks to CI and Canary workflows to abort builds if the `tools` folder is missing from publish outputs, reducing the risk of releasing incomplete runtime images. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR41-R60) [[2]](diffhunk://#diff-4b56c7c159ef6d182d11a4f6d189ea69d9ee8b2dfde7e7e920052190549c65e8R334-R372)
* Enhanced Canary workflow to list publish folder contents, upload the publish artifact for inspection, and copy-then-verify the `tools` folder if missing after publish.

**Project file update:**

* Added a fallback MSBuild target `CopyToolsToPublish` in `Listenarr.Api.csproj` to explicitly copy the `tools` folder into the publish output after `dotnet publish`, ensuring runtime images include required tooling.

**Documentation update:**

* Updated `CHANGELOG.md` to document the new fail-fast checks, publish verification steps, and improved build reliability.Enhanced CI and Canary workflows to verify the presence of the 'tools' folder in publish outputs, aborting builds if missing. Updated Listenarr.Api.csproj to explicitly copy the tools folder after publish, reducing risk of broken runtime images. Changelog updated to reflect these improvements.