### PR TITLE
Bump version to 0.2.33

### DIFF
--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -4,8 +4,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     
-    <Version>0.2.32</Version>
-    <AssemblyVersion>0.2.32</AssemblyVersion>
+    <Version>0.2.33</Version>
+    <AssemblyVersion>0.2.33</AssemblyVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>


### PR DESCRIPTION
This PR bumps the application version to 0.2.33.
The change was produced automatically by the CI canary workflow.