### PR TITLE
Bump version to 0.2.38

### DIFF
--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -4,8 +4,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     
-    <Version>0.2.37</Version>
-    <AssemblyVersion>0.2.37</AssemblyVersion>
+    <Version>0.2.38</Version>
+    <AssemblyVersion>0.2.38</AssemblyVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>


### PR DESCRIPTION
This PR bumps the application version to 0.2.38.
The change was produced automatically by the CI canary workflow.