### PR TITLE
Dependency updates

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -12,7 +12,7 @@
         "@phosphor-icons/vue": "^2.2.1",
         "@vueuse/core": "^14.0.0",
         "pinia": "^3.0.3",
-        "vue": "^3.5.22",
+        "vue": "^3.5.24",
         "vue-router": "^4.5.1",
         "web-vitals": "^5.1.0"
       },

--- a/fe/package.json
+++ b/fe/package.json
@@ -26,7 +26,7 @@
     "@phosphor-icons/vue": "^2.2.1",
     "@vueuse/core": "^14.0.0",
     "pinia": "^3.0.3",
-    "vue": "^3.5.22",
+    "vue": "^3.5.24",
     "vue-router": "^4.5.1",
     "web-vitals": "^5.1.0"
   },


### PR DESCRIPTION
This pull request updates several dependencies in the frontend project to their latest versions, focusing on the Vue ecosystem and related tooling. The main changes are version bumps for core libraries and development tools, as well as some cleanup of unused or deprecated packages in the lock file. These updates will help ensure compatibility, improved performance, and access to new features.

**Dependency Upgrades**

* Upgraded `vue` to version `3.5.24` and `@tsconfig/node22` to `22.0.5` for improved compatibility and features. [[1]](diffhunk://#diff-f5c8bb8efdcc3ee124fed83d22faee7d5d8ab774d4ebf29e78900eaad85b12c2L15-R20) [[2]](diffhunk://#diff-0e16f7a098f05dcb68ecbb3ab31190a41af3e91b1cd86965f8d5ea9823fc025dL29-R34)
* Updated `eslint-plugin-vue` to `10.6.0`, which brings new linting rules and support for the latest Vue features. [[1]](diffhunk://#diff-f5c8bb8efdcc3ee124fed83d22faee7d5d8ab774d4ebf29e78900eaad85b12c2L33-R33) [[2]](diffhunk://#diff-0e16f7a098f05dcb68ecbb3ab31190a41af3e91b1cd86965f8d5ea9823fc025dL47-R47) [[3]](diffhunk://#diff-f5c8bb8efdcc3ee124fed83d22faee7d5d8ab774d4ebf29e78900eaad85b12c2L4609-R4593)
* Upgraded `vite-plugin-vue-devtools` to `8.0.5` and `vitest` (plus all related Vitest packages) to `4.0.13`, providing better testing and development experience. [[1]](diffhunk://#diff-f5c8bb8efdcc3ee124fed83d22faee7d5d8ab774d4ebf29e78900eaad85b12c2L43-R44) [[2]](diffhunk://#diff-f5c8bb8efdcc3ee124fed83d22faee7d5d8ab774d4ebf29e78900eaad85b12c2L2448-R2481) [[3]](diffhunk://#diff-f5c8bb8efdcc3ee124fed83d22faee7d5d8ab774d4ebf29e78900eaad85b12c2L2502-R2562) [[4]](diffhunk://#diff-f5c8bb8efdcc3ee124fed83d22faee7d5d8ab774d4ebf29e78900eaad85b12c2L9155-R9105)
* Updated `chai` to `6.2.1` and `tinyrainbow` to `3.0.3`, ensuring compatibility with the latest testing libraries. [[1]](diffhunk://#diff-f5c8bb8efdcc3ee124fed83d22faee7d5d8ab774d4ebf29e78900eaad85b12c2L3617-L3628) [[2]](diffhunk://#diff-f5c8bb8efdcc3ee124fed83d22faee7d5d8ab774d4ebf29e78900eaad85b12c2L8489-R8418)

**Cleanup and Removal of Deprecated Packages**

* Removed unused or deprecated packages from `package-lock.json`, including `cac`, `check-error`, `deep-eql`, `loupe`, `pathval`, `strip-literal`, `tinypool`, `tinyspy`, and `vite-node`, reducing lock file bloat and potential security risks. [[1]](diffhunk://#diff-f5c8bb8efdcc3ee124fed83d22faee7d5d8ab774d4ebf29e78900eaad85b12c2L3527-L3536) [[2]](diffhunk://#diff-f5c8bb8efdcc3ee124fed83d22faee7d5d8ab774d4ebf29e78900eaad85b12c2L3663-L3672) [[3]](diffhunk://#diff-f5c8bb8efdcc3ee124fed83d22faee7d5d8ab774d4ebf29e78900eaad85b12c2L4118-L4127) [[4]](diffhunk://#diff-f5c8bb8efdcc3ee124fed83d22faee7d5d8ab774d4ebf29e78900eaad85b12c2L6445-L6451) [[5]](diffhunk://#diff-f5c8bb8efdcc3ee124fed83d22faee7d5d8ab774d4ebf29e78900eaad85b12c2L7089-L7098) [[6]](diffhunk://#diff-f5c8bb8efdcc3ee124fed83d22faee7d5d8ab774d4ebf29e78900eaad85b12c2L8298-L8317) [[7]](diffhunk://#diff-f5c8bb8efdcc3ee124fed83d22faee7d5d8ab774d4ebf29e78900eaad85b12c2L8489-R8418) [[8]](diffhunk://#diff-f5c8bb8efdcc3ee124fed83d22faee7d5d8ab774d4ebf29e78900eaad85b12c2L8954-L8976)

**Other Dependency Updates**

* Updated `postcss-selector-parser` to `7.1.0`, improving CSS selector parsing for linting and tooling.