### PR TITLE
Fix Playwright startup issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,9 @@ appsettings.Production.json
 **/config/dataprotection-keys/
 **/dataprotection-keys/
 
+# Nix config
+*.nix
+
 ##########################
 # OS & System Files      #
 ##########################

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN apt-get update \
 	&& apt-get install -y --no-install-recommends nodejs \
 	&& node --version \
 	&& npm --version \
-	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 COPY --from=build /app/publish .
 # Install Playwright
@@ -41,6 +40,7 @@ RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 	&& sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-bullseye-prod bullseye main" > /etc/apt/sources.list.d/microsoft.list' \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends powershell \
+	&& pwsh playwright.ps1 install-deps \
 	&& pwsh playwright.ps1 install \
 	&& apt-get remove -y powershell \
 	&& apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,8 @@ RUN apt-get update \
 	&& npm --version \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
-RUN dotnet build "Listenarr.Api.csproj" -c Release -o /app/build
-
-FROM build AS publish
-RUN dotnet publish "Listenarr.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false
-# Pre-install Playwright browsers to avoid runtime download delays
-RUN cd /app/publish && bash playwright.sh install
+RUN dotnet build "Listenarr.Api.csproj" -c Release -o /app/build \
+	&& dotnet publish "Listenarr.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
 WORKDIR /app
@@ -39,5 +35,14 @@ RUN apt-get update \
 	&& npm --version \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
-COPY --from=publish /app/publish .
+COPY --from=build /app/publish .
+# Install Playwright
+RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+	&& sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-bullseye-prod bullseye main" > /etc/apt/sources.list.d/microsoft.list' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends powershell \
+	&& pwsh playwright.ps1 install \
+	&& apt-get remove -y powershell \
+	&& apt-get clean
+
 ENTRYPOINT ["dotnet", "Listenarr.Api.dll"]


### PR DESCRIPTION
This installs Playwright assets into the final Docker image. Application startup (and the Docker build itself) was previously failing due to them being missing.

Caveat: I know almost nothing about Playwright or C# development (looks like Java, so I find it readable) so I could be wrong about any of this, open to feedback.

Notes:
* I removed the intermediate `publish` image and do the build and publish steps in `build`. It doesn't seem like the additional step is necessary.
* Playwright installation was previously failing because `playwright.sh` was missing, apparently it isn't supported (see [this issue](https://github.com/microsoft/playwright-dotnet/issues/2870#issuecomment-1963594845)). ~There still seem to be runtime checks in `listenarr.api/Program.cs` which are probably deprecated as well.~ edit: these went away when I added the `pwsh playwright.ps1 install-deps` step to the build.
* I suspect it would be a big improvement for build times if the node and playwright stuff could be installed _before_ the dotnet build happens since that could be cached and not re-run for every code change, but I haven't worked out how that all hangs together yet.

Fixes #265 