### PR TITLE
Fix download import pipeline for single-file torrents

### DIFF
--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -17,19 +17,19 @@
   
   <ItemGroup>
     <PackageReference Include="AsyncKeyedLock" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.23" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.23" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.*" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.11" />
     <PackageReference Include="Polly" Version="8.5.0" />
     <PackageReference Include="SharpCompress" Version="0.36.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.23">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.*">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.23" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.*" />
     <PackageReference Include="Microsoft.Playwright" Version="1.48.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.67" />

--- a/listenarr.api/Services/Adapters/QbittorrentAdapter.cs
+++ b/listenarr.api/Services/Adapters/QbittorrentAdapter.cs
@@ -595,14 +595,22 @@ namespace Listenarr.Api.Services.Adapters
                     return result;
                 }
 
-                // Extract the first subdirectory from file path (qBittorrent uses / separator even on Windows)
+                // For multi-file torrents, files are inside a subfolder (e.g. "FolderName/file.mkv").
+                // For single-file torrents, the file has no directory component (e.g. "file.m4b").
+                // In both cases, construct the full content path so the import targets the
+                // correct file/folder rather than the entire save_path directory.
                 var pathParts = fileName.Split('/');
-                var subfolder = pathParts.Length > 1 ? pathParts[0] : string.Empty;
-
-                // Construct output path
-                var outputPath = !string.IsNullOrEmpty(subfolder) 
-                    ? System.IO.Path.Combine(savePath, subfolder)
-                    : savePath;
+                string outputPath;
+                if (pathParts.Length > 1)
+                {
+                    // Multi-file torrent: use the top-level subfolder
+                    outputPath = System.IO.Path.Combine(savePath, pathParts[0]);
+                }
+                else
+                {
+                    // Single-file torrent: use the full file path
+                    outputPath = System.IO.Path.Combine(savePath, fileName);
+                }
 
                 // ✅ Apply remote path mapping
                 result.ContentPath = await _pathMappingService.TranslatePathAsync(client.Id, outputPath);

--- a/listenarr.api/Services/DownloadMonitorService.cs
+++ b/listenarr.api/Services/DownloadMonitorService.cs
@@ -669,8 +669,17 @@ namespace Listenarr.Api.Services
 
                     var baseUrl = $"{(client.UseSSL ? "https" : "http")}://{client.Host}:{client.Port}";
 
-                    using var http = _httpClientFactory.CreateClient("DownloadClient");
-                    _logger.LogInformation("Created HttpClient from factory for qbittorrent polling. BaseAddress={BaseAddress}", http.BaseAddress);
+                    // Create an HttpClient with its own CookieContainer so the qBittorrent
+                    // SID cookie from login is stored and sent with subsequent requests.
+                    // The factory "DownloadClient" has UseCookies=false which breaks qBit auth.
+                    var cookieJar = new System.Net.CookieContainer();
+                    using var handler = new HttpClientHandler
+                    {
+                        CookieContainer = cookieJar,
+                        UseCookies = true,
+                        AutomaticDecompression = System.Net.DecompressionMethods.All
+                    };
+                    using var http = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(30) };
 
                     // Login
                     using var loginData = new FormUrlEncodedContent(new[]
@@ -939,21 +948,23 @@ namespace Listenarr.Api.Services
                                     _completionCandidates[dl.Id] = DateTime.UtcNow;
                                     _logger.LogInformation("Download {DownloadId} observed as complete candidate (qBittorrent). Torrent: {TorrentName}, Path: {Path}. Waiting for stability window.",
                                         dl.Id, matched.Name, completionPath);
-                                    
-                                    // Update download status to Completed in database so it stops being re-added to candidates
+
+                                    // Update progress but do NOT set status to Completed yet.
+                                    // Setting Completed here races with DownloadProcessingBackgroundService
+                                    // which picks up Completed downloads and starts importing before the
+                                    // stability window expires. Keep status as Downloading until finalization.
                                     try
                                     {
-                                        dl.Status = DownloadStatus.Completed;
                                         dl.Progress = 100M;
                                         dbContext.Downloads.Update(dl);
                                         await dbContext.SaveChangesAsync(cancellationToken);
-                                        _logger.LogDebug("Updated download {DownloadId} status to Completed in database", dl.Id);
+                                        _logger.LogDebug("Updated download {DownloadId} progress to 100%% in database (status remains {Status})", dl.Id, dl.Status);
                                     }
                                     catch (Exception ex2)
                                     {
-                                        _logger.LogWarning(ex2, "Failed to update download {DownloadId} status to Completed", dl.Id);
+                                        _logger.LogWarning(ex2, "Failed to update download {DownloadId} progress", dl.Id);
                                     }
-                                    
+
                                     // Broadcast candidate so UI can surface it immediately
                                     _ = BroadcastCandidateUpdateAsync(dl, true, cancellationToken);
                                     continue;

--- a/listenarr.api/Services/DownloadProcessingBackgroundService.cs
+++ b/listenarr.api/Services/DownloadProcessingBackgroundService.cs
@@ -230,13 +230,20 @@ namespace Listenarr.Api.Services
                         }
 
                         // Use V2 pattern: Call GetImportItem to resolve the accurate path
-                        // Build a basic QueueItem from the download data
+                        // Build a basic QueueItem from the download data.
+                        // Prefer ClientContentPath (the torrent's content_path, i.e. the actual
+                        // file/folder) over DownloadPath (save_path, i.e. the download directory).
+                        // Using save_path for single-file torrents would resolve to the entire
+                        // downloads directory and import every file in it.
+                        var clientContentPath = dl.Metadata?.TryGetValue("ClientContentPath", out var ccp) == true
+                            ? ccp?.ToString()
+                            : null;
                         var preliminaryItem = new QueueItem
                         {
                             Id = dl.Id,
                             Title = dl.Title ?? "Unknown",
                             Status = "completed",
-                            ContentPath = dl.FinalPath ?? dl.DownloadPath,
+                            ContentPath = dl.FinalPath ?? clientContentPath ?? dl.DownloadPath,
                             DownloadClientId = dl.DownloadClientId
                         };
 

--- a/listenarr.api/Services/DownloadService.cs
+++ b/listenarr.api/Services/DownloadService.cs
@@ -2287,6 +2287,17 @@ namespace Listenarr.Api.Services
                     try
                     {
                         var clientDownloads = listenarrDownloads.Where(d => d.DownloadClientId == client.Id).ToList();
+
+                        // SAFETY: Skip purging when the client returned 0 queue items but we have
+                        // active downloads tracked. This prevents accidental deletion when the client
+                        // is temporarily unreachable (GetQueueAsync returns empty list on network errors).
+                        if (clientQueue.Count == 0 && clientDownloads.Any())
+                        {
+                            _logger.LogWarning("Skipping orphan purge for client {ClientName}: client returned 0 queue items but {Count} downloads are tracked. Client may be temporarily unreachable.",
+                                client.Name, clientDownloads.Count);
+                            continue;
+                        }
+
                         var mappedDownloadIds = mappedFiltered.Select(q => q.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
                         var orphanedDownloads = clientDownloads.Where(d =>

--- a/listenarr.infrastructure/Listenarr.Infrastructure.csproj
+++ b/listenarr.infrastructure/Listenarr.Infrastructure.csproj
@@ -6,7 +6,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.23" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.*">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

Fixes multiple issues causing single-file torrent downloads (e.g. from MyAnonamouse) to fail to import or to catastrophically import the entire downloads directory instead of the target file.

- **DownloadMonitorService cookie auth**: The factory `HttpClient` "DownloadClient" has `UseCookies=false`, dropping the qBittorrent SID cookie. Now creates a local `HttpClient` with its own `CookieContainer`.
- **Single-file torrent path resolution** (`QbittorrentAdapter.GetImportItemAsync`): For single-file torrents the subfolder was empty, so `outputPath` resolved to `save_path` (the entire downloads directory). Now uses `Path.Combine(savePath, fileName)`.
- **Race condition fix** (`DownloadMonitorService`): Was setting status to `Completed` before the stability window expired, allowing `DownloadProcessingBackgroundService` to pick up the download too early. Now only updates progress without changing status until finalization.
- **Path fallback fix** (`DownloadProcessingBackgroundService`): Was using `dl.FinalPath ?? dl.DownloadPath` (= `save_path`). Now prefers `ClientContentPath` from metadata (`content_path` = actual file).
- **Purge safety check** (`DownloadService`): Skips orphan purge when the client returns 0 queue items but active downloads exist, preventing deletion during transient connectivity issues.
- **EF Core version wildcards**: Uses `8.*` for all EF Core packages to avoid NU1605 version mismatch warnings.

## Test plan

- [x] Built and deployed to homelab Docker container
- [x] Triggered download of single-file M4B torrent from MyAnonamouse via Listenarr
- [x] Verified DownloadMonitorService successfully detects completion (cookie fix working)
- [x] Verified stability window prevents premature processing (race condition fix working)
- [x] Verified correct file path resolution (single-file fix: `/data/downloads/file.m4b` not `/data/downloads/`)
- [x] Verified successful import to audiobook library (only 1 file moved, not entire directory)
- [x] Verified purge safety check prevents accidental deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)