### PR TITLE
Remote Mapping Save Bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.2.51] - 2026-02-23
+
+### Fixed
+- **UI (Remote Path Mapping):** Fixed Remote Path Mapping modal Save action by ensuring the shared `ModalForm` includes `id="modal-form"` so footer Save buttons using `form="modal-form"` correctly submit the form.
+
+
 ## [0.2.50] - 2026-02-22
 
 ### Changed

--- a/fe/.env.production
+++ b/fe/.env.production
@@ -1,5 +1,5 @@
 # Production Environment Configuration
 VITE_API_BASE_URL=/api
 VITE_APP_TITLE=Listenarr
-VITE_APP_VERSION=0.2.50
+VITE_APP_VERSION=0.2.51
 VITE_DEV_TOOLS=false

--- a/fe/package.json
+++ b/fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "listenarr-fe",
-  "version": "0.2.50",
+  "version": "0.2.51",
   "private": true,
   "type": "module",
   "engines": {

--- a/fe/src/components/feedback/ModalForm.vue
+++ b/fe/src/components/feedback/ModalForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <form @submit.prevent="onSubmit" ref="formEl" class="modal-form">
+  <form id="modal-form" @submit.prevent="onSubmit" ref="formEl" class="modal-form">
     <slot />
   </form>
 </template>


### PR DESCRIPTION
### Fixed
- **UI (Remote Path Mapping):** Fixed Remote Path Mapping modal Save action by ensuring the shared `ModalForm` includes `id="modal-form"` so footer Save buttons using `form="modal-form"` correctly submit the form. (Closes #364)