### PR TITLE
Bump version to 0.2.51

### DIFF
--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>0.2.50</Version>
-    <AssemblyVersion>0.2.50</AssemblyVersion>
+    <Version>0.2.51</Version>
+    <AssemblyVersion>0.2.51</AssemblyVersion>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>  


### PR DESCRIPTION
This PR bumps the application version to 0.2.51.
The change was produced automatically by the CI canary workflow.