### PR TITLE
Bump version to 0.2.54

### DIFF
--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>0.2.53</Version>
-    <AssemblyVersion>0.2.53</AssemblyVersion>
+    <Version>0.2.54</Version>
+    <AssemblyVersion>0.2.54</AssemblyVersion>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>  


### PR DESCRIPTION
This PR bumps the application version to 0.2.54.
The change was produced automatically by the CI canary workflow.