### PR TITLE
ffmpeg crashing, synology/docker trust model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.55] - 2026-03-01
+
+### Added
+- **Regression coverage for trust/proxy behavior:** Added API tests validating `*Arr standard` forwarded-header trust configuration and caller redaction behavior differences between public-network and private-network callers.
+
+### Changed
+- **`*Arr standard` reverse-proxy trust model:** Updated forwarded-header handling to trust common private proxy networks (`10/8`, `172.16/12`, `192.168/16`, `fc00::/7`, `fe80::/10`) and process `X-Forwarded-Host` in addition to `X-Forwarded-For`/`X-Forwarded-Proto` for Docker/Synology/reverse-proxy deployments.
+- **Secret redaction trust policy:** Adjusted secret redaction decisions to match `*Arr standard` behavior by treating local/private-network callers as trusted perimeter callers, while still requiring admin/API-key authentication for public-network callers.
+- **Security/auth guidance text:** Updated API/Swagger guidance text to reflect trusted-network redaction behavior (`trusted-network/auth`) instead of localhost-only wording.
+
+### Fixed
+- **Indexer test + download client test in containerized LAN setups:** Removed over-restrictive private/loopback target blocking for these connectivity test flows, preventing false failures like successful test followed by save errors in common Synology Docker bridge-network deployments.
+
 ## [0.2.54] - 2026-02-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Indexer test + download client test in containerized LAN setups:** Removed over-restrictive private/loopback target blocking for these connectivity test flows, preventing false failures like successful test followed by save errors in common Synology Docker bridge-network deployments.
+- **Download client modal test credential fallback:** When testing an existing download client from the edit modal, the request now includes the client `id` so backend test logic can reuse saved credentials (for example password/API key) when the input field is left blank.
 
 ## [0.2.54] - 2026-02-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Regression coverage for trust/proxy behavior:** Added API tests validating `*Arr standard` forwarded-header trust configuration and caller redaction behavior differences between public-network and private-network callers.
 
 ### Changed
-- **`*Arr standard` reverse-proxy trust model:** Updated forwarded-header handling to trust common private proxy networks (`10/8`, `172.16/12`, `192.168/16`, `fc00::/7`, `fe80::/10`) and process `X-Forwarded-Host` in addition to `X-Forwarded-For`/`X-Forwarded-Proto` for Docker/Synology/reverse-proxy deployments.
+- **`*arr standard` reverse-proxy trust model:** Updated forwarded-header handling to trust common private proxy networks (`10/8`, `172.16/12`, `192.168/16`, `fc00::/7`, `fe80::/10`) and process `X-Forwarded-Host` in addition to `X-Forwarded-For`/`X-Forwarded-Proto` for Docker/Synology/reverse-proxy deployments.
 - **Secret redaction trust policy:** Adjusted secret redaction decisions to match `*Arr standard` behavior by treating local/private-network callers as trusted perimeter callers, while still requiring admin/API-key authentication for public-network callers.
 - **Security/auth guidance text:** Updated API/Swagger guidance text to reflect trusted-network redaction behavior (`trusted-network/auth`) instead of localhost-only wording.
 

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "listenarr-fe",
-  "version": "0.2.52",
+  "version": "0.2.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "listenarr-fe",
-      "version": "0.2.52",
+      "version": "0.2.55",
       "hasInstallScript": true,
       "dependencies": {
         "@material/material-color-utilities": "^0.4.0",

--- a/fe/package.json
+++ b/fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "listenarr-fe",
-  "version": "0.2.52",
+  "version": "0.2.55",
   "private": true,
   "type": "module",
   "engines": {

--- a/fe/src/__tests__/DownloadClientFormModal.spec.ts
+++ b/fe/src/__tests__/DownloadClientFormModal.spec.ts
@@ -60,7 +60,7 @@ describe('DownloadClientFormModal', () => {
     expect(apiKeyComponent.exists()).toBe(true)
   })
 
-  it('test button on modal uses current input values (no ID sent)', async () => {
+  it('test button on modal uses current input values and includes ID for existing client fallback', async () => {
     const api = await import('@/services/api')
     ;(api.testDownloadClient as unknown) = vi.fn(async (config: unknown) => ({ success: true, message: 'ok', client: config }))
 
@@ -98,11 +98,11 @@ describe('DownloadClientFormModal', () => {
     expect((api.testDownloadClient as unknown)).toHaveBeenCalled()
     const calledWith = (api.testDownloadClient as unknown).mock.calls[0][0]
     expect(calledWith.host).toBe('edited.local')
-    // ID should NOT be sent when testing modal inputs to avoid DB fallback
-    expect(calledWith.id).toBeUndefined()
+    // Existing client id should be sent so backend can reuse saved credentials when needed.
+    expect(calledWith.id).toBe('3')
   })
 
-  it('modal prepopulates password from DB and uses empty password when cleared', async () => {
+  it('modal sends existing client ID when password is cleared so backend can pull saved password', async () => {
     const api = await import('@/services/api')
     ;(api.testDownloadClient as unknown) = vi.fn(async (config: unknown) => ({ success: true, message: 'ok', client: config }))
 
@@ -143,7 +143,8 @@ describe('DownloadClientFormModal', () => {
 
     expect((api.testDownloadClient as unknown)).toHaveBeenCalled()
     const calledWith = (api.testDownloadClient as unknown).mock.calls[0][0]
-    // Because we omit the id, server will NOT pull DB password; we should send empty password
+    // We still send an empty password input, but include id so backend can reuse saved credentials.
     expect(calledWith.password).toBe('')
+    expect(calledWith.id).toBe('4')
   })
 })

--- a/fe/src/components/domain/download/DownloadClientFormModal.vue
+++ b/fe/src/components/domain/download/DownloadClientFormModal.vue
@@ -478,12 +478,11 @@ const closeModal = () => {
 const testConnection = async () => {
   testing.value = true
   try {
-    // Build config for testing with proper settings structure
-    // Match the structure that handleSubmit uses to ensure settings are properly formatted
-    // Build a test-only config — do NOT include an `id` so that the server
-    // does not perform DB fallbacks when running a connection test. The
-    // full configuration (with id) is only sent on save.
+    // Build config for testing with proper settings structure.
+    // When editing an existing client, include id so the backend can reuse
+    // saved credentials (for example password/apiKey) if the form input is left blank.
     const configToTest: Partial<DownloadClientConfiguration> = {
+      ...(props.editingClient?.id ? { id: props.editingClient.id } : {}),
       name: formData.value.name,
       type: formData.value.type,
       host: formData.value.host,

--- a/listenarr.api/Controllers/ConfigurationController.cs
+++ b/listenarr.api/Controllers/ConfigurationController.cs
@@ -341,32 +341,6 @@ namespace Listenarr.Api.Controllers
                     }
                 }
 
-                if (SecurityRequestUtils.ShouldRedactSecretsForCaller(HttpContext))
-                {
-                    var scheme = config.UseSSL ? "https" : "http";
-                    var host = (config.Host ?? string.Empty).Trim();
-                    var baseUrl = string.IsNullOrWhiteSpace(host)
-                        ? string.Empty
-                        : $"{scheme}://{host}{(config.Port > 0 ? $":{config.Port}" : string.Empty)}/";
-
-                    if (!string.IsNullOrWhiteSpace(baseUrl))
-                    {
-                        if (!OutboundRequestSecurity.TryValidateExternalHttpUrl(baseUrl, out var reason, allowPrivateTargets: false))
-                        {
-                            return BadRequest(new { success = false, message = $"Blocked download client test target: {reason}" });
-                        }
-
-                        if (Uri.TryCreate(baseUrl, UriKind.Absolute, out var targetUri))
-                        {
-                            var ok = await OutboundRequestSecurity.TryValidateResolvedExternalHttpUriAsync(targetUri, _logger, allowPrivateTargets: false);
-                            if (!ok)
-                            {
-                                return BadRequest(new { success = false, message = "Blocked download client test target: DNS resolved to private or loopback address" });
-                            }
-                        }
-                    }
-                }
-
                 // Delegate to download service to perform protocol-specific lightweight tests
                 var (Success, Message, Client) = await _downloadService.TestDownloadClientAsync(config);
                 var clientResponse = Client;
@@ -459,7 +433,8 @@ namespace Listenarr.Api.Controllers
                     _logger.LogWarning("[ConfigurationController] Authentication is enabled and user is not authenticated. Returning 401.");
                     return Unauthorized();
                 }
-                // Do not expose startup secrets to remote unauthenticated callers, even when auth is disabled.
+                // *Arr standard trust model: public remote unauthenticated callers get redacted
+                // values, while trusted local/private-network callers can read full config.
                 if (SecurityRequestUtils.ShouldRedactSecretsForCaller(HttpContext))
                 {
                     config = ApiResponseRedactor.RedactStartupConfig(config);

--- a/listenarr.api/Controllers/IndexersController.cs
+++ b/listenarr.api/Controllers/IndexersController.cs
@@ -50,9 +50,6 @@ namespace Listenarr.Api.Controllers
         private bool ShouldRedactIndexerSecretsForCaller()
             => SecurityRequestUtils.ShouldRedactSecretsForCaller(HttpContext);
 
-        private bool AllowPrivateOutboundTargetsForCaller()
-            => SecurityRequestUtils.IsLoopbackRequest(HttpContext) || SecurityRequestUtils.IsAuthenticatedAdminOrApiKey(HttpContext);
-
         private Indexer RedactIndexerForCaller(Indexer indexer)
             => ShouldRedactIndexerSecretsForCaller() ? ApiResponseRedactor.RedactIndexer(indexer) : indexer;
 
@@ -66,24 +63,16 @@ namespace Listenarr.Api.Controllers
                 ? ApiResponseRedactor.RedactedValue
                 : mamId;
 
-        private async Task<string?> ValidateOutboundUrlForCallerAsync(string url)
+        private Task<string?> ValidateOutboundUrlForCallerAsync(string url)
         {
-            var allowPrivateTargets = AllowPrivateOutboundTargetsForCaller();
-            if (!OutboundRequestSecurity.TryValidateExternalHttpUrl(url, out var reason, allowPrivateTargets))
+            // *Arr standard behavior: allow private/loopback destinations for indexer connectivity
+            // tests/imports, but still enforce absolute HTTP(S) URLs and block embedded credentials.
+            if (!OutboundRequestSecurity.TryValidateExternalHttpUrl(url, out var reason, allowPrivateTargets: true))
             {
-                return reason;
+                return Task.FromResult<string?>(reason);
             }
 
-            if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
-            {
-                var dnsOk = await OutboundRequestSecurity.TryValidateResolvedExternalHttpUriAsync(uri, _logger, allowPrivateTargets);
-                if (!dnsOk)
-                {
-                    return "DNS resolved to private or loopback address";
-                }
-            }
-
-            return null;
+            return Task.FromResult<string?>(null);
         }
 
         private async Task<HttpResponseMessage> SendValidatedAsync(
@@ -98,7 +87,8 @@ namespace Listenarr.Api.Controllers
                 uri,
                 _httpClientNoRedirect,
                 _logger,
-                allowPrivateTargets: AllowPrivateOutboundTargetsForCaller(),
+                // *Arr standard behavior for indexers: allow private/loopback destinations.
+                allowPrivateTargets: true,
                 completionOption: completionOption,
                 cancellationToken: cancellationToken);
             return response;

--- a/listenarr.api/Controllers/ProwlarrCompatController.cs
+++ b/listenarr.api/Controllers/ProwlarrCompatController.cs
@@ -375,7 +375,21 @@ namespace Listenarr.Api.Controllers
             var authGuard = RequireAuthenticatedIfEnabled();
             if (authGuard != null) return authGuard;
             Response.ContentType = "application/json";
-            return Ok(System.Array.Empty<object>());
+            // Frontend and compatibility clients both call this endpoint. Return persisted
+            // indexers in the standard shape used by the UI so versioned routing does not
+            // accidentally break first-party indexer listing.
+            var indexers = _dbContext.Indexers
+                .OrderBy(i => i.Priority)
+                .ThenBy(i => i.Name)
+                .AsNoTracking()
+                .ToList();
+
+            if (SecurityRequestUtils.ShouldRedactSecretsForCaller(HttpContext))
+            {
+                indexers = indexers.Select(ApiResponseRedactor.RedactIndexer).ToList();
+            }
+
+            return Ok(indexers);
         }
 
         /// <summary>
@@ -823,6 +837,13 @@ namespace Listenarr.Api.Controllers
                 }
 
                 if (HttpContext?.Response != null) HttpContext.Response.ContentType = "application/json";
+
+            // Accept a single object payload as well as arrays. This keeps the endpoint
+            // tolerant when callers post one indexer at a time.
+            if (payload.ValueKind == System.Text.Json.JsonValueKind.Object)
+            {
+                return await PostIndexer(payload);
+            }
 
             if (payload.ValueKind != System.Text.Json.JsonValueKind.Array)
             {

--- a/listenarr.api/Program.cs
+++ b/listenarr.api/Program.cs
@@ -265,6 +265,23 @@ builder.Services
 // Required for [Authorize] / role policies used by controllers.
 builder.Services.AddAuthorization();
 
+// *Arr standard proxy trust model:
+// trust forwarded headers from RFC1918/RFC4193/link-local proxy networks that are
+// common in Docker/Synology/reverse-proxy deployments.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders =
+        ForwardedHeaders.XForwardedFor |
+        ForwardedHeaders.XForwardedProto |
+        ForwardedHeaders.XForwardedHost;
+
+    options.KnownNetworks.Add(new Microsoft.AspNetCore.HttpOverrides.IPNetwork(IPAddress.Parse("10.0.0.0"), 8));
+    options.KnownNetworks.Add(new Microsoft.AspNetCore.HttpOverrides.IPNetwork(IPAddress.Parse("172.16.0.0"), 12));
+    options.KnownNetworks.Add(new Microsoft.AspNetCore.HttpOverrides.IPNetwork(IPAddress.Parse("192.168.0.0"), 16));
+    options.KnownNetworks.Add(new Microsoft.AspNetCore.HttpOverrides.IPNetwork(IPAddress.Parse("fc00::"), 7));
+    options.KnownNetworks.Add(new Microsoft.AspNetCore.HttpOverrides.IPNetwork(IPAddress.Parse("fe80::"), 10));
+});
+
 // Add SignalR for real-time updates
 builder.Services.AddSignalR()
     .AddJsonProtocol(options =>
@@ -723,7 +740,7 @@ builder.Services.AddSwaggerGen(options =>
         "   - Use `SessionBearer` (`Bearer <sessionToken>`) or `SessionTokenHeader` (`<sessionToken>`).",
         "3. API key flow:",
         "   - Listenarr auto-generates an API key on first run.",
-        "   - Read the current key from `GET /api/v{version}/Configuration/startupconfig` (localhost/auth redaction rules apply).",
+        "   - Read the current key from `GET /api/v{version}/Configuration/startupconfig` (trusted-network/auth redaction rules apply).",
         "   - Rotate the key with `POST /api/v{version}/Configuration/apikey/regenerate` (Administrator required).",
         "   - `POST /api/v{version}/Configuration/apikey/generate-initial` is localhost bootstrap only and typically returns 409 after setup.",
         "   - Use `ApiKeyHeader` (`<apiKey>`) or `ApiKeyAuthorization` (`ApiKey <apiKey>`)."
@@ -769,7 +786,7 @@ builder.Services.AddSwaggerGen(options =>
         {
             "Use `X-Api-Key: <apiKey>`.",
             "API keys are auto-generated on first run.",
-            "Read the current key from `GET /api/v{version}/Configuration/startupconfig` (localhost/auth redaction rules apply).",
+            "Read the current key from `GET /api/v{version}/Configuration/startupconfig` (trusted-network/auth redaction rules apply).",
             "Regenerate with `POST /api/v{version}/Configuration/apikey/regenerate` (Administrator required)."
         })
     });
@@ -783,7 +800,7 @@ builder.Services.AddSwaggerGen(options =>
         {
             "Use `Authorization: ApiKey <apiKey>`.",
             "API keys are auto-generated on first run.",
-            "Read the current key from `GET /api/v{version}/Configuration/startupconfig` (localhost/auth redaction rules apply).",
+            "Read the current key from `GET /api/v{version}/Configuration/startupconfig` (trusted-network/auth redaction rules apply).",
             "Regenerate with `POST /api/v{version}/Configuration/apikey/regenerate` (Administrator required)."
         })
     });
@@ -956,16 +973,9 @@ if (app.Environment.IsDevelopment())
     });
 }
 
-// Use forwarded headers middleware (must be early in pipeline)
-// This processes X-Forwarded-For and X-Forwarded-Proto headers from the reverse proxy.
-// By default, ASP.NET Core will only trust forwarded headers from loopback addresses (127.0.0.1, ::1).
-// This is safe for most self-hosted and direct scenarios, and will work behind a reverse proxy if the proxy runs locally or you set ASPNETCORE_FORWARDEDHEADERS_ENABLED=true.
-// For advanced scenarios, set trusted proxies via KnownProxies/KnownNetworks if needed.
-app.UseForwardedHeaders(new ForwardedHeadersOptions
-{
-    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
-    // Do not set KnownProxies/KnownNetworks here for maximum compatibility
-});
+// Use forwarded headers middleware (must be early in pipeline).
+// Options are configured in DI to trust common private proxy networks.
+app.UseForwardedHeaders();
 
 // Note: HTTPS redirection is handled by the reverse proxy, not by this application
 

--- a/listenarr.api/Services/AutomaticSearchService.cs
+++ b/listenarr.api/Services/AutomaticSearchService.cs
@@ -42,13 +42,29 @@ namespace Listenarr.Api.Services
             _logger.LogInformation("AutomaticSearchService started. Will search monitored audiobooks every {Hours} hours", _searchInterval.TotalHours);
 
             // Wait for application to be fully started before first search
-            await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken);
+            try
+            {
+                await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("AutomaticSearchService canceled before first search cycle");
+                return;
+            }
 
             while (!stoppingToken.IsCancellationRequested)
             {
                 try
                 {
                     await PerformAutomaticSearchesAsync(stoppingToken);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (OperationCanceledException ex)
+                {
+                    _logger.LogWarning(ex, "Automatic search cycle canceled/timed out; continuing");
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                     _logger.LogError(ex, "Error during automatic search cycle");
@@ -59,7 +75,7 @@ namespace Listenarr.Api.Services
                 {
                     await Task.Delay(_searchInterval, stoppingToken);
                 }
-                catch (TaskCanceledException)
+                catch (OperationCanceledException)
                 {
                     // Expected when stopping
                     break;
@@ -118,6 +134,14 @@ namespace Listenarr.Api.Services
 
                     _logger.LogInformation("Processed audiobook '{Title}' - queued {QueuedCount} downloads",
                         audiobook.Title, downloadsQueuedForBook);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (OperationCanceledException ex)
+                {
+                    _logger.LogWarning(ex, "Automatic search processing canceled/timed out for audiobook '{Title}' (ID: {Id})", audiobook.Title, audiobook.Id);
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                     _logger.LogError(ex, "Error processing audiobook '{Title}' (ID: {Id})", audiobook.Title, audiobook.Id);

--- a/listenarr.api/Services/CompletedDownloadHandlingService.cs
+++ b/listenarr.api/Services/CompletedDownloadHandlingService.cs
@@ -71,6 +71,14 @@ namespace Listenarr.Api.Services
                     _pollingInterval = TimeSpan.FromSeconds(settings.PollingIntervalSeconds);
                 }
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("CompletedDownloadHandlingService startup canceled");
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogWarning(ex, "CompletedDownloadHandlingService settings load canceled/timed out during startup; using default interval");
+            }
             catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                 _logger.LogWarning(ex, "Failed to load polling interval from settings, using default");
             }
@@ -94,12 +102,27 @@ namespace Listenarr.Api.Services
                 {
                     await ProcessCompletedDownloadsAsync(stoppingToken);
                 }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (OperationCanceledException ex)
+                {
+                    _logger.LogWarning(ex, "CompletedDownloadHandlingService cycle canceled/timed out; continuing");
+                }
                 catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                     _logger.LogError(ex, "Error in CompletedDownloadHandlingService");
                 }
 
                 // Wait before next poll
-                await Task.Delay(_pollingInterval, stoppingToken);
+                try
+                {
+                    await Task.Delay(_pollingInterval, stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
             }
 
             _logger.LogInformation("CompletedDownloadHandlingService background task stopped");
@@ -220,6 +243,14 @@ namespace Listenarr.Api.Services
                         }
                     }
                 }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogWarning(ex, "CompletedDownloadHandlingService processing canceled/timed out");
             }
             catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                 _logger.LogError(ex, "Error in CompletedDownloadHandlingService");

--- a/listenarr.api/Services/DownloadMonitorService.cs
+++ b/listenarr.api/Services/DownloadMonitorService.cs
@@ -436,7 +436,15 @@ namespace Listenarr.Api.Services
             _logger.LogInformation("Download Monitor Service starting");
 
             // Wait a bit before starting to ensure the app is fully initialized
-            await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("Download Monitor Service canceled before start");
+                return;
+            }
 
             // Attempt to read configured polling interval from ApplicationSettings (fallback to current default)
             try
@@ -459,6 +467,15 @@ namespace Listenarr.Api.Services
                 }
                 _logger.LogInformation("DownloadMonitorService polling interval set to {Interval}s", _pollingInterval.TotalSeconds);
             }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("Download Monitor Service canceled while reading startup configuration");
+                return;
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogWarning(ex, "Download monitor settings load canceled/timed out; using default polling interval");
+            }
             catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                 _logger.LogDebug(ex, "Failed to read polling interval from settings, using default {Default}s", _pollingInterval.TotalSeconds);
             }
@@ -473,12 +490,27 @@ namespace Listenarr.Api.Services
                 {
                     _logger.LogWarning(ex, "Download monitor HTTP request timed out; continuing background polling loop");
                 }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (OperationCanceledException ex)
+                {
+                    _logger.LogWarning(ex, "Download monitor operation canceled/timed out; continuing background polling loop");
+                }
                 catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                     _logger.LogError(ex, "Error in Download Monitor Service");
                 }
 
                 // Wait before next poll
-                await Task.Delay(_pollingInterval, stoppingToken);
+                try
+                {
+                    await Task.Delay(_pollingInterval, stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
             }
 
             _logger.LogInformation("Download Monitor Service stopping");

--- a/listenarr.api/Services/DownloadProcessingBackgroundService.cs
+++ b/listenarr.api/Services/DownloadProcessingBackgroundService.cs
@@ -53,6 +53,14 @@ namespace Listenarr.Api.Services
             {
                 await ResetStuckJobsAsync(stoppingToken);
             }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("Download processing startup reset canceled during shutdown");
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogWarning(ex, "Download processing startup reset canceled/timed out; continuing");
+            }
             catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                 _logger.LogError(ex, "Failed to reset stuck jobs on startup");
             }
@@ -66,6 +74,14 @@ namespace Listenarr.Api.Services
 
                     await ProcessQueueAsync(stoppingToken);
                     await ProcessRetryJobsAsync(stoppingToken);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (OperationCanceledException ex)
+                {
+                    _logger.LogWarning(ex, "Download processing cycle canceled/timed out; continuing");
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                     _logger.LogError(ex, "Error processing download queue");

--- a/listenarr.api/Services/DownloadProcessingChannelConsumer.cs
+++ b/listenarr.api/Services/DownloadProcessingChannelConsumer.cs
@@ -19,23 +19,46 @@ namespace Listenarr.Api.Services
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            await foreach (var jobId in _channel.ReadAllAsync(stoppingToken))
+            try
             {
-                try
+                await foreach (var jobId in _channel.ReadAllAsync(stoppingToken))
                 {
-                    using var scope = _scopeFactory.CreateScope();
-                    var queueService = scope.ServiceProvider.GetRequiredService<IDownloadProcessingQueueService>();
-                    var job = await queueService.GetJobAsync(jobId);
-                    if (job == null) continue;
+                    try
+                    {
+                        using var scope = _scopeFactory.CreateScope();
+                        var queueService = scope.ServiceProvider.GetRequiredService<IDownloadProcessingQueueService>();
+                        var job = await queueService.GetJobAsync(jobId);
+                        if (job == null) continue;
 
-                    // If job is pending, trigger immediate processing via DownloadProcessingBackgroundService by
-                    // leaving it in Pending state. The background service will pick it up during its next loop.
-                    // Optionally we could signal a processing mechanism here; keep lightweight for now.
-                    _logger.LogDebug("Channel consumer observed job {JobId}", jobId);
+                        // If job is pending, trigger immediate processing via DownloadProcessingBackgroundService by
+                        // leaving it in Pending state. The background service will pick it up during its next loop.
+                        // Optionally we could signal a processing mechanism here; keep lightweight for now.
+                        _logger.LogDebug("Channel consumer observed job {JobId}", jobId);
+                    }
+                    catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
+                    catch (OperationCanceledException ex)
+                    {
+                        _logger.LogWarning(ex, "Channel consumer canceled/timed out while handling job {JobId}", jobId);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
+                        _logger.LogWarning(ex, "Failed to handle channel job {JobId}", jobId);
+                    }
                 }
-                catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
-                    _logger.LogWarning(ex, "Failed to handle channel job {JobId}", jobId);
-                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("Download processing channel consumer stopping due to host shutdown");
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogWarning(ex, "Download processing channel stream canceled/timed out");
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogError(ex, "Unhandled error in DownloadProcessingChannelConsumer stream");
             }
         }
     }

--- a/listenarr.api/Services/FfmpegInstallBackgroundService.cs
+++ b/listenarr.api/Services/FfmpegInstallBackgroundService.cs
@@ -60,7 +60,13 @@ namespace Listenarr.Api.Services
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
                 // Shutdown requested
-                            System.Diagnostics.Debug.WriteLine("Suppressed non-fatal exception in catch block.");
+                _logger.LogDebug("FFmpeg installer background service canceled due to host shutdown.");
+            }
+            catch (OperationCanceledException ex)
+            {
+                // Treat timeout/cancellation from installer HTTP calls as non-fatal so this hosted
+                // service cannot stop the entire application host.
+                _logger.LogWarning(ex, "FFmpeg installer background service canceled/timed out; continuing without bundled ffprobe.");
             }
             catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                 _logger.LogWarning(ex, "Error while attempting background ffprobe installation");

--- a/listenarr.api/Services/FfmpegInstallerService.cs
+++ b/listenarr.api/Services/FfmpegInstallerService.cs
@@ -27,6 +27,17 @@ namespace Listenarr.Api.Services
         {
             _logger = logger;
             _httpClient = new HttpClient();
+            // Use a longer timeout than HttpClient's 100s default because static ffprobe archives
+            // can be large and hosts may have slow links. Allow override via environment variable.
+            var timeoutSeconds = 300;
+            var timeoutEnv = Environment.GetEnvironmentVariable("LISTENARR_FFPROBE_DOWNLOAD_TIMEOUT_SECONDS");
+            if (!string.IsNullOrWhiteSpace(timeoutEnv)
+                && int.TryParse(timeoutEnv, out var parsedSeconds)
+                && parsedSeconds > 0)
+            {
+                timeoutSeconds = parsedSeconds;
+            }
+            _httpClient.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
             _autoInstall = Environment.GetEnvironmentVariable("LISTENARR_AUTO_INSTALL_FFPROBE")?.ToLower() != "false"; // default true
             _startupConfigService = startupConfigService;
             _processRunner = processRunner;
@@ -476,6 +487,16 @@ namespace Listenarr.Api.Services
 
                 _logger.LogInformation("ffprobe installed to {Path}", ffprobePath);
                 return ffprobePath;
+            }
+            catch (TaskCanceledException ex)
+            {
+                _logger.LogWarning(ex, "ffprobe download/install timed out or was canceled");
+                return null;
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogWarning(ex, "ffprobe download/install was canceled");
+                return null;
             }
             catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                 _logger.LogWarning(ex, "Failed to download or install ffprobe");

--- a/listenarr.api/Services/ImageCacheCleanupService.cs
+++ b/listenarr.api/Services/ImageCacheCleanupService.cs
@@ -38,6 +38,15 @@ namespace Listenarr.Api.Services
                         _logger.LogInformation("Daily image cache cleanup completed successfully");
                     }
                 }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    _logger.LogInformation("Image Cache Cleanup Service cancellation requested");
+                    break;
+                }
+                catch (OperationCanceledException ex)
+                {
+                    _logger.LogWarning(ex, "Image cache cleanup operation canceled/timed out; continuing");
+                }
                 catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                     _logger.LogError(ex, "Error occurred during image cache cleanup");
                 }
@@ -47,7 +56,7 @@ namespace Listenarr.Api.Services
                 {
                     await Task.Delay(_cleanupInterval, stoppingToken);
                 }
-                catch (TaskCanceledException)
+                catch (OperationCanceledException)
                 {
                     _logger.LogInformation("Image Cache Cleanup Service is stopping");
                     break;
@@ -70,9 +79,13 @@ namespace Listenarr.Api.Services
                 {
                     await Task.Delay(timeUntilMidnight, stoppingToken);
                 }
-                catch (TaskCanceledException)
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                 {
                     _logger.LogInformation("Image Cache Cleanup Service is stopping before first cleanup");
+                }
+                catch (OperationCanceledException ex)
+                {
+                    _logger.LogWarning(ex, "Image Cache Cleanup Service startup delay canceled/timed out");
                 }
             }
         }

--- a/listenarr.api/Services/MetadataRescanService.cs
+++ b/listenarr.api/Services/MetadataRescanService.cs
@@ -105,11 +105,26 @@ namespace Listenarr.Api.Services
 
                     await Task.WhenAll(tasks);
                 }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (OperationCanceledException ex)
+                {
+                    _logger.LogWarning(ex, "Metadata rescan cycle canceled/timed out; continuing");
+                }
                 catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                     _logger.LogError(ex, "Error while running metadata rescan");
                 }
 
-                await Task.Delay(_interval, stoppingToken);
+                try
+                {
+                    await Task.Delay(_interval, stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
             }
             _logger.LogInformation("MetadataRescanService stopping");
         }

--- a/listenarr.api/Services/MoveBackgroundService.cs
+++ b/listenarr.api/Services/MoveBackgroundService.cs
@@ -29,14 +29,16 @@ namespace Listenarr.Api.Services
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            await foreach (var job in _moveQueue.Reader.ReadAllAsync(stoppingToken))
+            try
             {
-                if (stoppingToken.IsCancellationRequested) break;
-
-                try
+                await foreach (var job in _moveQueue.Reader.ReadAllAsync(stoppingToken))
                 {
-                    _logger.LogInformation("Processing move job {JobId} for audiobook {AudiobookId} to {Path}", job.Id, job.AudiobookId, job.RequestedPath);
-                    _moveQueue.UpdateJobStatus(job.Id, "Processing");
+                    if (stoppingToken.IsCancellationRequested) break;
+
+                    try
+                    {
+                        _logger.LogInformation("Processing move job {JobId} for audiobook {AudiobookId} to {Path}", job.Id, job.AudiobookId, job.RequestedPath);
+                        _moveQueue.UpdateJobStatus(job.Id, "Processing");
 
                     using var scope = _scopeFactory.CreateScope();
                     var db = scope.ServiceProvider.GetRequiredService<ListenArrDbContext>();
@@ -477,17 +479,34 @@ namespace Listenarr.Api.Services
                         _logger.LogError(ex, "Move job {JobId} failed", job.Id);
                         // Failure during move job — attempt counts updated and history recorded where configured
                     }
-                }
-                catch (OperationCanceledException)
-                {
-                    break;
-                }
-                catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
-                    _logger.LogError(ex, "Unexpected error processing move job {JobId}", job.Id);
-                    try { _moveQueue.UpdateJobStatus(job.Id, "Failed", ex.Message); } catch (Exception caughtEx_2) when (caughtEx_2 is not OperationCanceledException && caughtEx_2 is not OutOfMemoryException && caughtEx_2 is not StackOverflowException) { 
-                        System.Diagnostics.Debug.WriteLine("Suppressed non-fatal exception in catch block.");
+                    }
+                    catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
+                    catch (OperationCanceledException ex)
+                    {
+                        _logger.LogWarning(ex, "Move job {JobId} canceled/timed out", job.Id);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
+                        _logger.LogError(ex, "Unexpected error processing move job {JobId}", job.Id);
+                        try { _moveQueue.UpdateJobStatus(job.Id, "Failed", ex.Message); } catch (Exception caughtEx_2) when (caughtEx_2 is not OperationCanceledException && caughtEx_2 is not OutOfMemoryException && caughtEx_2 is not StackOverflowException) { 
+                            System.Diagnostics.Debug.WriteLine("Suppressed non-fatal exception in catch block.");
+                        }
                     }
                 }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("MoveBackgroundService stopping due to host shutdown");
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogWarning(ex, "MoveBackgroundService channel stream canceled/timed out");
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogError(ex, "Unhandled error in MoveBackgroundService channel loop");
             }
         }
 

--- a/listenarr.api/Services/QueueMonitorService.cs
+++ b/listenarr.api/Services/QueueMonitorService.cs
@@ -60,10 +60,14 @@ namespace Listenarr.Api.Services
             {
                 await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
                 _logger.LogInformation("Queue Monitor Service cancelled before start");
                 return;
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogWarning(ex, "Queue Monitor startup delay canceled/timed out; continuing");
             }
 
             while (!stoppingToken.IsCancellationRequested)
@@ -72,10 +76,14 @@ namespace Listenarr.Api.Services
                 {
                     await MonitorQueueAsync(stoppingToken);
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                 {
                     // Cancellation requested - exit gracefully
                     break;
+                }
+                catch (OperationCanceledException ex)
+                {
+                    _logger.LogWarning(ex, "Queue monitor cycle canceled/timed out; continuing");
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                     _logger.LogError(ex, "Error in Queue Monitor Service");

--- a/listenarr.api/Services/ScanBackgroundService.cs
+++ b/listenarr.api/Services/ScanBackgroundService.cs
@@ -528,6 +528,10 @@ namespace Listenarr.Api.Services
                 {
                     _logger.LogInformation("ScanBackgroundService cancellation requested");
                 }
+                catch (OperationCanceledException ex)
+                {
+                    _logger.LogWarning(ex, "ScanBackgroundService job stream canceled/timed out unexpectedly; continuing");
+                }
                 catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                     _logger.LogError(ex, "Unhandled error in ScanBackgroundService loop");
                 }

--- a/listenarr.api/Services/SecurityRequestUtils.cs
+++ b/listenarr.api/Services/SecurityRequestUtils.cs
@@ -60,10 +60,10 @@ public static class SecurityRequestUtils
     }
 
     public static bool ShouldRedactSecretsForCaller(HttpContext? context)
-        // Do not trust private-network source IPs as "local" for secret redaction decisions.
-        // In reverse-proxy/container setups the app may only see the proxy's private IP if
-        // forwarded headers are not explicitly trusted, which would otherwise bypass redaction.
-        => !IsLoopbackRequest(context) && !IsAuthenticatedAdminOrApiKey(context);
+        // *Arr standard trust model:
+        // - trusted local/private-network callers may receive non-redacted config payloads
+        // - public-network callers must authenticate as admin/API-key to receive secrets
+        => !IsLocalOrPrivateRequest(context) && !IsAuthenticatedAdminOrApiKey(context);
 
     public static string HashSecretForLog(string? secret, string prefix = "sha256")
     {

--- a/listenarr.api/Services/StartupDbNormalizer.cs
+++ b/listenarr.api/Services/StartupDbNormalizer.cs
@@ -55,6 +55,10 @@ namespace Listenarr.Api.Services
                 // shutdown requested - ignore
                             System.Diagnostics.Debug.WriteLine("Suppressed non-fatal exception in catch block.");
             }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogWarning(ex, "StartupDbNormalizer: operation canceled/timed out; skipping normalization pass");
+            }
             catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                 _logger.LogError(ex, "StartupDbNormalizer: unexpected error while running normalization");
             }

--- a/listenarr.api/Services/TempFileCleanupService.cs
+++ b/listenarr.api/Services/TempFileCleanupService.cs
@@ -41,6 +41,15 @@ namespace Listenarr.Api.Services
                         _logger.LogInformation("Temp file cleanup completed successfully");
                     }
                 }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    _logger.LogInformation("Temp File Cleanup Service cancellation requested");
+                    break;
+                }
+                catch (OperationCanceledException ex)
+                {
+                    _logger.LogWarning(ex, "Temp file cleanup operation canceled/timed out; continuing");
+                }
                 catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                     _logger.LogError(ex, "Error occurred during temp file cleanup");
                 }
@@ -50,7 +59,7 @@ namespace Listenarr.Api.Services
                 {
                     await Task.Delay(_cleanupInterval, stoppingToken);
                 }
-                catch (TaskCanceledException)
+                catch (OperationCanceledException)
                 {
                     _logger.LogInformation("Temp File Cleanup Service is stopping");
                     break;

--- a/tests/Listenarr.Api.Tests/ConfigurationControllerDownloadClientTests.cs
+++ b/tests/Listenarr.Api.Tests/ConfigurationControllerDownloadClientTests.cs
@@ -1,0 +1,192 @@
+using System.Net;
+using Listenarr.Api.Controllers;
+using Listenarr.Api.Hubs;
+using Listenarr.Api.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Listenarr.Api.Tests
+{
+    public class ConfigurationControllerDownloadClientTests
+    {
+        [Fact]
+        public async Task TestDownloadClientConfiguration_RemoteCaller_AllowsPrivateHost_AndRedactsSecrets()
+        {
+            // Arrange
+            var configurationService = new Mock<IConfigurationService>(MockBehavior.Strict);
+            var downloadService = new Mock<IDownloadService>(MockBehavior.Strict);
+            var logger = new LoggerFactory().CreateLogger<ConfigurationController>();
+            var userService = Mock.Of<IUserService>();
+            var settingsHub = Mock.Of<IHubContext<SettingsHub>>();
+
+            var testedClient = new DownloadClientConfiguration
+            {
+                Id = "client-1",
+                Name = "NZBGet",
+                Type = "nzbget",
+                Host = "192.168.1.50",
+                Port = 6789,
+                Username = "nzb-user",
+                Password = "nzb-pass",
+                UseSSL = false,
+                IsEnabled = true,
+                Settings = new Dictionary<string, object>
+                {
+                    ["apiKey"] = "very-secret-api-key"
+                }
+            };
+
+            downloadService
+                .Setup(x => x.TestDownloadClientAsync(It.IsAny<DownloadClientConfiguration>()))
+                .ReturnsAsync((true, "Connection successful", testedClient));
+
+            var controller = new ConfigurationController(
+                configurationService.Object,
+                logger,
+                userService,
+                settingsHub,
+                downloadService.Object,
+                null!);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Connection.RemoteIpAddress = IPAddress.Parse("8.8.8.8");
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+            var request = new DownloadClientConfiguration
+            {
+                // Keep ID empty so the endpoint does not try to merge from an existing saved config.
+                Id = string.Empty,
+                Name = "NZBGet",
+                Type = "nzbget",
+                Host = "192.168.1.50",
+                Port = 6789,
+                Username = "nzb-user",
+                Password = "nzb-pass",
+                UseSSL = false,
+                IsEnabled = true,
+                Settings = new Dictionary<string, object>
+                {
+                    ["apiKey"] = "very-secret-api-key"
+                }
+            };
+
+            // Act
+            var actionResult = await controller.TestDownloadClientConfiguration(request);
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(actionResult.Result);
+            Assert.NotNull(ok.Value);
+            var payload = ok.Value!;
+
+            var successProp = payload.GetType().GetProperty("success");
+            Assert.NotNull(successProp);
+            Assert.True((bool)successProp!.GetValue(payload)!);
+
+            var clientProp = payload.GetType().GetProperty("client");
+            Assert.NotNull(clientProp);
+            var redactedClient = Assert.IsType<DownloadClientConfiguration>(clientProp!.GetValue(payload));
+            Assert.Equal(ApiResponseRedactor.RedactedValue, redactedClient.Username);
+            Assert.Equal(ApiResponseRedactor.RedactedValue, redactedClient.Password);
+            Assert.True(redactedClient.Settings.TryGetValue("apiKey", out var redactedApiKey));
+            Assert.Equal(ApiResponseRedactor.RedactedValue, redactedApiKey?.ToString());
+
+            downloadService.Verify(
+                x => x.TestDownloadClientAsync(It.Is<DownloadClientConfiguration>(c =>
+                    c.Host == "192.168.1.50" && c.Port == 6789)),
+                Times.Once);
+            configurationService.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task TestDownloadClientConfiguration_PrivateNetworkCaller_DoesNotRedactSecrets()
+        {
+            // Arrange
+            var configurationService = new Mock<IConfigurationService>(MockBehavior.Strict);
+            var downloadService = new Mock<IDownloadService>(MockBehavior.Strict);
+            var logger = new LoggerFactory().CreateLogger<ConfigurationController>();
+            var userService = Mock.Of<IUserService>();
+            var settingsHub = Mock.Of<IHubContext<SettingsHub>>();
+
+            var testedClient = new DownloadClientConfiguration
+            {
+                Id = "client-2",
+                Name = "NZBGet",
+                Type = "nzbget",
+                Host = "192.168.1.50",
+                Port = 6789,
+                Username = "nzb-user",
+                Password = "nzb-pass",
+                UseSSL = false,
+                IsEnabled = true,
+                Settings = new Dictionary<string, object>
+                {
+                    ["apiKey"] = "very-secret-api-key"
+                }
+            };
+
+            downloadService
+                .Setup(x => x.TestDownloadClientAsync(It.IsAny<DownloadClientConfiguration>()))
+                .ReturnsAsync((true, "Connection successful", testedClient));
+
+            var controller = new ConfigurationController(
+                configurationService.Object,
+                logger,
+                userService,
+                settingsHub,
+                downloadService.Object,
+                null!);
+
+            var httpContext = new DefaultHttpContext();
+            // Simulate a trusted LAN/Synology-Docker caller.
+            httpContext.Connection.RemoteIpAddress = IPAddress.Parse("192.168.1.23");
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+            var request = new DownloadClientConfiguration
+            {
+                Id = string.Empty,
+                Name = "NZBGet",
+                Type = "nzbget",
+                Host = "192.168.1.50",
+                Port = 6789,
+                Username = "nzb-user",
+                Password = "nzb-pass",
+                UseSSL = false,
+                IsEnabled = true,
+                Settings = new Dictionary<string, object>
+                {
+                    ["apiKey"] = "very-secret-api-key"
+                }
+            };
+
+            // Act
+            var actionResult = await controller.TestDownloadClientConfiguration(request);
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(actionResult.Result);
+            Assert.NotNull(ok.Value);
+            var payload = ok.Value!;
+
+            var successProp = payload.GetType().GetProperty("success");
+            Assert.NotNull(successProp);
+            Assert.True((bool)successProp!.GetValue(payload)!);
+
+            var clientProp = payload.GetType().GetProperty("client");
+            Assert.NotNull(clientProp);
+            var returnedClient = Assert.IsType<DownloadClientConfiguration>(clientProp!.GetValue(payload));
+            Assert.Equal("nzb-user", returnedClient.Username);
+            Assert.Equal("nzb-pass", returnedClient.Password);
+            Assert.True(returnedClient.Settings.TryGetValue("apiKey", out var apiKey));
+            Assert.Equal("very-secret-api-key", apiKey?.ToString());
+
+            downloadService.Verify(
+                x => x.TestDownloadClientAsync(It.Is<DownloadClientConfiguration>(c =>
+                    c.Host == "192.168.1.50" && c.Port == 6789)),
+                Times.Once);
+            configurationService.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/tests/Listenarr.Api.Tests/ConfigurationControllerDownloadClientTests.cs
+++ b/tests/Listenarr.Api.Tests/ConfigurationControllerDownloadClientTests.cs
@@ -5,7 +5,7 @@ using Listenarr.Api.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -19,7 +19,7 @@ namespace Listenarr.Api.Tests
             // Arrange
             var configurationService = new Mock<IConfigurationService>(MockBehavior.Strict);
             var downloadService = new Mock<IDownloadService>(MockBehavior.Strict);
-            var logger = new LoggerFactory().CreateLogger<ConfigurationController>();
+            var logger = NullLogger<ConfigurationController>.Instance;
             var userService = Mock.Of<IUserService>();
             var settingsHub = Mock.Of<IHubContext<SettingsHub>>();
 
@@ -107,7 +107,7 @@ namespace Listenarr.Api.Tests
             // Arrange
             var configurationService = new Mock<IConfigurationService>(MockBehavior.Strict);
             var downloadService = new Mock<IDownloadService>(MockBehavior.Strict);
-            var logger = new LoggerFactory().CreateLogger<ConfigurationController>();
+            var logger = NullLogger<ConfigurationController>.Instance;
             var userService = Mock.Of<IUserService>();
             var settingsHub = Mock.Of<IHubContext<SettingsHub>>();
 

--- a/tests/Listenarr.Api.Tests/ForwardedHeadersTrustModelTests.cs
+++ b/tests/Listenarr.Api.Tests/ForwardedHeadersTrustModelTests.cs
@@ -1,0 +1,42 @@
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+using HttpOverridesIPNetwork = Microsoft.AspNetCore.HttpOverrides.IPNetwork;
+
+namespace Listenarr.Api.Tests
+{
+    public class ForwardedHeadersTrustModelTests : IClassFixture<ListenarrWebApplicationFactory>
+    {
+        private readonly ListenarrWebApplicationFactory _factory;
+
+        public ForwardedHeadersTrustModelTests(ListenarrWebApplicationFactory factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public void ForwardedHeadersOptions_TrustsCommonPrivateProxyNetworks()
+        {
+            using var scope = _factory.Services.CreateScope();
+            var options = scope.ServiceProvider.GetRequiredService<IOptions<ForwardedHeadersOptions>>().Value;
+
+            Assert.True(options.ForwardedHeaders.HasFlag(ForwardedHeaders.XForwardedFor));
+            Assert.True(options.ForwardedHeaders.HasFlag(ForwardedHeaders.XForwardedProto));
+            Assert.True(options.ForwardedHeaders.HasFlag(ForwardedHeaders.XForwardedHost));
+
+            Assert.Contains(options.KnownNetworks, network => Matches(network, "10.0.0.0", 8));
+            Assert.Contains(options.KnownNetworks, network => Matches(network, "172.16.0.0", 12));
+            Assert.Contains(options.KnownNetworks, network => Matches(network, "192.168.0.0", 16));
+            Assert.Contains(options.KnownNetworks, network => Matches(network, "fc00::", 7));
+            Assert.Contains(options.KnownNetworks, network => Matches(network, "fe80::", 10));
+        }
+
+        private static bool Matches(HttpOverridesIPNetwork network, string prefix, int prefixLength)
+        {
+            return network.Prefix.Equals(IPAddress.Parse(prefix)) && network.PrefixLength == prefixLength;
+        }
+    }
+}

--- a/tests/Listenarr.Api.Tests/IndexersAuthTests.cs
+++ b/tests/Listenarr.Api.Tests/IndexersAuthTests.cs
@@ -4,6 +4,8 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Listenarr.Domain.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -106,6 +108,45 @@ namespace Listenarr.Api.Tests
             Assert.IsType<Microsoft.AspNetCore.Mvc.OkObjectResult>(result);
             Assert.True(indexer.LastTestSuccessful);
             Assert.Null(indexer.LastTestError);
+        }
+
+        [Fact]
+        public async Task TestDraft_GenericIndexer_RemoteCaller_AllowsPrivateHost()
+        {
+            // Arrange - simulate a remote caller testing a private-network indexer URL.
+            var resp = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"ok\":true}")
+            };
+            var handler = new CaptureHandler(resp);
+            var controller = CreateController(handler);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Connection.RemoteIpAddress = IPAddress.Parse("8.8.8.8");
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+            var indexer = new Indexer
+            {
+                Name = "private-indexer",
+                Type = "Usenet",
+                Implementation = "Generic",
+                Url = "http://192.168.1.25"
+            };
+
+            // Act
+            var result = await controller.TestDraft(indexer);
+
+            // Assert - request should proceed instead of being blocked as private/loopback.
+            Assert.NotNull(handler.LastRequest);
+            Assert.Equal("192.168.1.25", handler.LastRequest!.RequestUri!.Host);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(ok.Value);
+            var payload = ok.Value!;
+            var successProp = payload.GetType().GetProperty("success");
+            Assert.NotNull(successProp);
+            Assert.True((bool)successProp!.GetValue(payload)!);
+            Assert.True(indexer.LastTestSuccessful);
         }
     }
 }

--- a/tests/Listenarr.Api.Tests/IndexersAuthTests.cs
+++ b/tests/Listenarr.Api.Tests/IndexersAuthTests.cs
@@ -7,7 +7,7 @@ using Listenarr.Domain.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Listenarr.Api.Tests
@@ -38,7 +38,7 @@ namespace Listenarr.Api.Tests
                 .Options;
 
             var db = new ListenArrDbContext(options);
-            var logger = new LoggerFactory().CreateLogger<Listenarr.Api.Controllers.IndexersController>();
+            var logger = NullLogger<Listenarr.Api.Controllers.IndexersController>.Instance;
             var client = new HttpClient(handler);
 
             return new Listenarr.Api.Controllers.IndexersController(db, logger, client);
@@ -136,10 +136,47 @@ namespace Listenarr.Api.Tests
             // Act
             var result = await controller.TestDraft(indexer);
 
-            // Assert - request should proceed instead of being blocked as private/loopback.
+            // Assert
             Assert.NotNull(handler.LastRequest);
             Assert.Equal("192.168.1.25", handler.LastRequest!.RequestUri!.Host);
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(ok.Value);
+            var payload = ok.Value!;
+            var successProp = payload.GetType().GetProperty("success");
+            Assert.NotNull(successProp);
+            Assert.True((bool)successProp!.GetValue(payload)!);
+            Assert.True(indexer.LastTestSuccessful);
+        }
 
+        [Fact]
+        public async Task TestDraft_GenericIndexer_PrivateNetworkCaller_AllowsPrivateHost()
+        {
+            // Arrange - trusted private-network caller can test private-network indexer URL.
+            var resp = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"ok\":true}")
+            };
+            var handler = new CaptureHandler(resp);
+            var controller = CreateController(handler);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Connection.RemoteIpAddress = IPAddress.Parse("192.168.1.20");
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+            var indexer = new Indexer
+            {
+                Name = "private-indexer",
+                Type = "Usenet",
+                Implementation = "Generic",
+                Url = "http://192.168.1.25"
+            };
+
+            // Act
+            var result = await controller.TestDraft(indexer);
+
+            // Assert
+            Assert.NotNull(handler.LastRequest);
+            Assert.Equal("192.168.1.25", handler.LastRequest!.RequestUri!.Host);
             var ok = Assert.IsType<OkObjectResult>(result);
             Assert.NotNull(ok.Value);
             var payload = ok.Value!;

--- a/tests/Listenarr.Api.Tests/ProwlarrEndpointsTests.cs
+++ b/tests/Listenarr.Api.Tests/ProwlarrEndpointsTests.cs
@@ -183,9 +183,10 @@ namespace Listenarr.Api.Tests
                 categories = new[] { 3030 }
             });
 
+            using var content = new StringContent(payload, System.Text.Encoding.UTF8, "application/json");
             var resp = await client.PostAsync(
                 "/api/v1/indexers",
-                new StringContent(payload, System.Text.Encoding.UTF8, "application/json"));
+                content);
 
             Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
 

--- a/tests/Listenarr.Api.Tests/ProwlarrEndpointsTests.cs
+++ b/tests/Listenarr.Api.Tests/ProwlarrEndpointsTests.cs
@@ -169,6 +169,35 @@ namespace Listenarr.Api.Tests
         }
 
         [Fact]
+        public async Task IndexersList_Post_AcceptsSingleObject()
+        {
+            var client = _factory.CreateClient();
+
+            var payload = JsonSerializer.Serialize(new
+            {
+                name = "Single Object via Indexers",
+                implementation = "Newznab",
+                baseUrl = "http://localhost:18090",
+                apiPath = "api",
+                apiKey = "OBJECTKEY",
+                categories = new[] { 3030 }
+            });
+
+            var resp = await client.PostAsync(
+                "/api/v1/indexers",
+                new StringContent(payload, System.Text.Encoding.UTF8, "application/json"));
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+            using var stream = await resp.Content.ReadAsStreamAsync();
+            var doc = await JsonDocument.ParseAsync(stream);
+            Assert.True(doc.RootElement.TryGetProperty("accepted", out var accepted));
+            Assert.True(accepted.GetBoolean());
+            Assert.True(doc.RootElement.TryGetProperty("created", out var created));
+            Assert.True(created.GetInt32() >= 1);
+        }
+
+        [Fact]
         public async Task Indexers_Post_PersistsToDatabaseAndVisibleViaApi()
         {
             var client = _factory.CreateClient();


### PR DESCRIPTION
## Summary
This PR aligns Listenarr with the `*arr standard` trust model for Docker/Synology/reverse-proxy deployments, improves background-service resilience, and fixes download client modal test credential fallback.

## Changed
- Updated forwarded-header trust behavior to `*Arr standard` by trusting private proxy networks:
  - `10.0.0.0/8`
  - `172.16.0.0/12`
  - `192.168.0.0/16`
  - `fc00::/7`
  - `fe80::/10`
- Enabled `X-Forwarded-Host` alongside `X-Forwarded-For` and `X-Forwarded-Proto`.
- Updated caller trust/redaction behavior so private-network callers are treated as trusted perimeter callers, while public-network callers still require admin/API-key auth for unredacted values.
- Relaxed private-target blocking in indexer and download-client connectivity test flows for containerized LAN use cases.
- Hardened background/hosted service cancellation and timeout handling to reduce host-stop scenarios.

## Fixed
- Fixed download client edit-modal test behavior so existing client `id` is included in test payloads, allowing backend fallback to saved password/API key when input is blank.
- Fixed false-negative connection test behavior for private-network targets in common Synology/Docker bridge setups.
- Fixed FFprobe installer timeout/cancellation behavior that could bubble into host-level failures.

## Added
- Added API tests for forwarded-header trust model and private/public redaction behavior.
- Added/updated tests for indexer and download-client test flows.
- Added frontend unit test assertions for edit-modal test payload `id` behavior.

## Removed
- Removed over-restrictive private/loopback target blocking from download-client/indexer connectivity test paths.