### PR TITLE
Library optimizations

### DIFF
--- a/fe/src/__tests__/audiobookStatus.spec.ts
+++ b/fe/src/__tests__/audiobookStatus.spec.ts
@@ -66,4 +66,25 @@ describe('computeAudiobookStatus', () => {
 
     expect(computeAudiobookStatus(audiobook, new Set(), profiles)).toBe('quality-match')
   })
+
+  it('treats WavPack files as lossless', () => {
+    const audiobook = {
+      id: 5,
+      title: 'Lossless Book',
+      qualityProfileId: 10,
+      files: [{ id: 102, format: 'wv', container: 'wv' }],
+    } as Audiobook
+
+    const profiles: QualityProfile[] = [
+      {
+        id: 10,
+        name: 'Lossless',
+        cutoffQuality: 'lossless',
+        preferredFormats: ['wv'],
+        qualities: [{ quality: 'lossless', allowed: true, priority: 0 }],
+      },
+    ]
+
+    expect(computeAudiobookStatus(audiobook, new Set(), profiles)).toBe('quality-match')
+  })
 })

--- a/fe/src/utils/audiobookStatus.ts
+++ b/fe/src/utils/audiobookStatus.ts
@@ -129,7 +129,17 @@ function deriveQualityLabel(
   if (
     container.includes('flac') ||
     codec.includes('flac') ||
+    container.includes('alac') ||
     codec.includes('alac') ||
+    container.includes('aiff') ||
+    codec.includes('aiff') ||
+    container.includes('ape') ||
+    codec.includes('ape') ||
+    container.includes('dsd') ||
+    codec.includes('dsd') ||
+    container.includes('wv') ||
+    codec.includes('wv') ||
+    container.includes('wav') ||
     codec.includes('wav')
   ) {
     return 'lossless'

--- a/listenarr.api/Controllers/LibraryController.cs
+++ b/listenarr.api/Controllers/LibraryController.cs
@@ -49,6 +49,14 @@ namespace Listenarr.Api.Controllers
         private const int MetadataRescanMaxRequestsPerWindow = 5;
         private const int MetadataRescanMaxAsinLookupAttempts = 8;
         private const int MetadataRescanMaxIsbnConversionAttempts = 5;
+        private static readonly DownloadStatus[] ActiveLibraryDownloadStatuses =
+        {
+            DownloadStatus.Queued,
+            DownloadStatus.Downloading,
+            DownloadStatus.Paused,
+            DownloadStatus.Processing,
+            DownloadStatus.ImportPending
+        };
 
         private static string? ToStringOrFirst(object? value)
         {
@@ -102,15 +110,23 @@ namespace Listenarr.Api.Controllers
 
         private static bool ComputeWantedFlag(Audiobook audiobook)
         {
-            if (!audiobook.Monitored)
+            var files = audiobook.Files;
+            var hasTrackedFiles = files != null && files.Count > 0;
+            return ComputeWantedFlag(audiobook.Monitored, hasTrackedFiles, audiobook.FilePath);
+        }
+
+        private static bool ComputeWantedFlag(bool monitored, bool hasTrackedFiles, string? legacyFilePath)
+        {
+            if (!monitored)
             {
                 return false;
             }
 
             // The library list endpoint should not hit the filesystem for every book.
-            // Treat existing DB file records as the source of truth for wanted status.
-            var files = audiobook.Files;
-            return files == null || files.Count == 0;
+            // Use AudiobookFiles as the primary source of truth, but honor the legacy
+            // primary FilePath during the upgrade window so existing installs do not
+            // suddenly flip back to Wanted before file rows are backfilled.
+            return !hasTrackedFiles && string.IsNullOrWhiteSpace(legacyFilePath);
         }
 
         private static string ResolvePathWithOptionalBase(string? basePath, string candidatePath)
@@ -612,6 +628,8 @@ namespace Listenarr.Api.Controllers
                 return Ok(Array.Empty<LibraryAudiobookListItemDto>());
             }
 
+            // Keep this as a handful of set-based queries instead of a wide join so the
+            // list endpoint stays lean and avoids cartesian duplication across files and downloads.
             var audiobookIds = audiobooks.Select(a => a.Id).ToArray();
             var fileSummaries = await _dbContext.AudiobookFiles
                 .AsNoTracking()
@@ -646,18 +664,9 @@ namespace Listenarr.Api.Controllers
 
             var qualityProfilesById = qualityProfiles.ToDictionary(q => q.Id);
 
-            var activeDownloadStatuses = new[]
-            {
-                DownloadStatus.Queued,
-                DownloadStatus.Downloading,
-                DownloadStatus.Paused,
-                DownloadStatus.Processing,
-                DownloadStatus.ImportPending
-            };
-
             var activeDownloadAudiobookIds = await _dbContext.Downloads
                 .AsNoTracking()
-                .Where(d => d.AudiobookId.HasValue && activeDownloadStatuses.Contains(d.Status))
+                .Where(d => d.AudiobookId.HasValue && ActiveLibraryDownloadStatuses.Contains(d.Status))
                 .Select(d => d.AudiobookId!.Value)
                 .Distinct()
                 .ToListAsync();
@@ -667,8 +676,10 @@ namespace Listenarr.Api.Controllers
             var dto = audiobooks.Select(a =>
             {
                 filesByAudiobookId.TryGetValue(a.Id, out var files);
-                var hasFiles = files != null && files.Count > 0;
-                var wanted = a.Monitored && !hasFiles;
+                var hasTrackedFiles = files != null && files.Count > 0;
+                var hasLegacyFileSummary = !string.IsNullOrWhiteSpace(a.FilePath);
+                var hasAnyFile = hasTrackedFiles || hasLegacyFileSummary;
+                var wanted = ComputeWantedFlag(a.Monitored, hasTrackedFiles, a.FilePath);
                 QualityProfile? qualityProfile = null;
                 if (a.QualityProfileId.HasValue)
                 {
@@ -696,17 +707,16 @@ namespace Listenarr.Api.Controllers
                     FileSize = a.FileSize,
                     FileCount = files?.Count ?? 0,
                     Quality = a.Quality,
-                    QualityProfileId = a.QualityProfileId,
-                    AuthorAsins = a.AuthorAsins?.ToArray(),
-                    Wanted = wanted,
-                    Status = AudiobookStatusEvaluator.ComputeStatus(
-                        activeDownloadAudiobookIdSet.Contains(a.Id),
-                        wanted,
-                        hasFiles,
-                        a.Quality,
-                        qualityProfile,
-                        files)
-                };
+                     QualityProfileId = a.QualityProfileId,
+                     AuthorAsins = a.AuthorAsins?.ToArray(),
+                     Wanted = wanted,
+                     Status = AudiobookStatusEvaluator.ComputeStatus(
+                         activeDownloadAudiobookIdSet.Contains(a.Id),
+                         hasAnyFile,
+                         a.Quality,
+                         qualityProfile,
+                         files)
+                 };
             }).ToList();
 
             return Ok(dto);

--- a/listenarr.api/Controllers/LibraryController.cs
+++ b/listenarr.api/Controllers/LibraryController.cs
@@ -628,12 +628,10 @@ namespace Listenarr.Api.Controllers
                 return Ok(Array.Empty<LibraryAudiobookListItemDto>());
             }
 
-            // Keep this as a handful of set-based queries instead of a wide join so the
-            // list endpoint stays lean and avoids cartesian duplication across files and downloads.
-            var audiobookIds = audiobooks.Select(a => a.Id).ToArray();
+            // Because this endpoint already loads the entire audiobook table, fetch file
+            // summaries directly instead of expanding a large in-memory ID list into SQL.
             var fileSummaries = await _dbContext.AudiobookFiles
                 .AsNoTracking()
-                .Where(f => audiobookIds.Contains(f.AudiobookId))
                 .Select(f => new AudiobookFileStatusInfo
                 {
                     AudiobookId = f.AudiobookId,

--- a/listenarr.api/Models/LibraryAudiobookListItemDto.cs
+++ b/listenarr.api/Models/LibraryAudiobookListItemDto.cs
@@ -19,6 +19,7 @@ namespace Listenarr.Api.Models
         public int? Runtime { get; set; }
         public string? ImageUrl { get; set; }
         public bool Monitored { get; set; }
+        // Transitional legacy primary file summary retained for filters and upgrade compatibility.
         public string? FilePath { get; set; }
         public long? FileSize { get; set; }
         public int FileCount { get; set; }

--- a/listenarr.api/Services/AudiobookStatusEvaluator.cs
+++ b/listenarr.api/Services/AudiobookStatusEvaluator.cs
@@ -24,7 +24,6 @@ namespace Listenarr.Api.Services
 
         public static string ComputeStatus(
             bool isDownloading,
-            bool wanted,
             bool hasAnyFile,
             string? audiobookQuality,
             QualityProfile? qualityProfile,
@@ -33,11 +32,6 @@ namespace Listenarr.Api.Services
             if (isDownloading)
             {
                 return Downloading;
-            }
-
-            if (wanted)
-            {
-                return NoFile;
             }
 
             if (!hasAnyFile)
@@ -76,6 +70,11 @@ namespace Listenarr.Api.Services
 
             if (candidateFiles.Count == 0)
             {
+                if (files == null || files.Count == 0)
+                {
+                    return QualityMatch;
+                }
+
                 return QualityMismatch;
             }
 
@@ -157,7 +156,17 @@ namespace Listenarr.Api.Services
             var codec = Normalize(file?.Codec);
             if (container.Contains("flac", StringComparison.Ordinal)
                 || codec.Contains("flac", StringComparison.Ordinal)
+                || container.Contains("alac", StringComparison.Ordinal)
                 || codec.Contains("alac", StringComparison.Ordinal)
+                || container.Contains("aiff", StringComparison.Ordinal)
+                || codec.Contains("aiff", StringComparison.Ordinal)
+                || container.Contains("ape", StringComparison.Ordinal)
+                || codec.Contains("ape", StringComparison.Ordinal)
+                || container.Contains("dsd", StringComparison.Ordinal)
+                || codec.Contains("dsd", StringComparison.Ordinal)
+                || container.Contains("wv", StringComparison.Ordinal)
+                || codec.Contains("wv", StringComparison.Ordinal)
+                || container.Contains("wav", StringComparison.Ordinal)
                 || codec.Contains("wav", StringComparison.Ordinal))
             {
                 return "lossless";

--- a/tests/Listenarr.Api.Tests/AudiobookStatusEvaluatorTests.cs
+++ b/tests/Listenarr.Api.Tests/AudiobookStatusEvaluatorTests.cs
@@ -8,7 +8,7 @@ namespace Listenarr.Api.Tests
     public class AudiobookStatusEvaluatorTests
     {
         [Fact]
-        public void ComputeStatus_ReturnsNoFile_WhenWanted()
+        public void ComputeStatus_ReturnsNoFile_WhenHasNoFiles()
         {
             var status = AudiobookStatusEvaluator.ComputeStatus(
                 isDownloading: false,

--- a/tests/Listenarr.Api.Tests/AudiobookStatusEvaluatorTests.cs
+++ b/tests/Listenarr.Api.Tests/AudiobookStatusEvaluatorTests.cs
@@ -12,7 +12,6 @@ namespace Listenarr.Api.Tests
         {
             var status = AudiobookStatusEvaluator.ComputeStatus(
                 isDownloading: false,
-                wanted: true,
                 hasAnyFile: false,
                 audiobookQuality: null,
                 qualityProfile: null,
@@ -30,7 +29,7 @@ namespace Listenarr.Api.Tests
                 new() { Format = "mp3", Bitrate = 320000 }
             };
 
-            var status = AudiobookStatusEvaluator.ComputeStatus(false, false, true, null, profile, files);
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files);
 
             Assert.Equal(AudiobookStatusEvaluator.QualityMismatch, status);
         }
@@ -44,7 +43,7 @@ namespace Listenarr.Api.Tests
                 new() { Format = "m4b", Bitrate = 256000 }
             };
 
-            var status = AudiobookStatusEvaluator.ComputeStatus(false, false, true, null, profile, files);
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files);
 
             Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
         }
@@ -58,9 +57,42 @@ namespace Listenarr.Api.Tests
                 new() { Format = "m4b", Bitrate = 192000 }
             };
 
-            var status = AudiobookStatusEvaluator.ComputeStatus(false, false, true, null, profile, files);
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files);
 
             Assert.Equal(AudiobookStatusEvaluator.QualityMismatch, status);
+        }
+
+        [Fact]
+        public void ComputeStatus_ReturnsQualityMatch_WhenOnlyLegacyFileSummaryExists()
+        {
+            var profile = CreateProfile(cutoffQuality: "256kbps", preferredFormats: new List<string> { "m4b" });
+
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files: null);
+
+            Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
+        }
+
+        [Fact]
+        public void ComputeStatus_TreatsWavPackAsLossless()
+        {
+            var profile = new QualityProfile
+            {
+                Name = "Lossless Profile",
+                CutoffQuality = "lossless",
+                PreferredFormats = new List<string> { "wv" },
+                Qualities = new List<QualityDefinition>
+                {
+                    new() { Quality = "lossless", Priority = 0 }
+                }
+            };
+            var files = new List<AudiobookFileStatusInfo>
+            {
+                new() { Format = "wv", Container = "wv" }
+            };
+
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files);
+
+            Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
         }
 
         private static QualityProfile CreateProfile(string cutoffQuality, List<string> preferredFormats)

--- a/tests/Listenarr.Api.Tests/LibraryController_WantedFlagRegressionTests.cs
+++ b/tests/Listenarr.Api.Tests/LibraryController_WantedFlagRegressionTests.cs
@@ -64,5 +64,46 @@ namespace Listenarr.Api.Tests
 
             Assert.False(wanted);
         }
+
+        [Fact]
+        public async Task GetAll_TreatsLegacyFilePathAsNotWanted_WhenNoFileRowsExist()
+        {
+            var options = new DbContextOptionsBuilder<ListenArrDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            using var db = new ListenArrDbContext(options);
+
+            var book = new Audiobook
+            {
+                Title = "Legacy FilePath Book",
+                Monitored = true,
+                FilePath = @"C:\legacy\book.m4b",
+                FileSize = 2048
+            };
+            db.Audiobooks.Add(book);
+            await db.SaveChangesAsync();
+
+            using var provider = new ServiceCollection().BuildServiceProvider();
+            var controller = new LibraryController(
+                Mock.Of<IAudiobookRepository>(),
+                Mock.Of<IImageCacheService>(),
+                NullLogger<LibraryController>.Instance,
+                db,
+                provider.GetRequiredService<IServiceScopeFactory>(),
+                Mock.Of<IFileNamingService>());
+
+            var actionResult = await controller.GetAll();
+            var ok = Assert.IsType<OkObjectResult>(actionResult);
+
+            var json = JsonSerializer.Serialize(ok.Value, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+            using var doc = JsonDocument.Parse(json);
+            var item = doc.RootElement
+                .EnumerateArray()
+                .Single(element => element.GetProperty("id").GetInt32() == book.Id);
+
+            Assert.False(item.GetProperty("wanted").GetBoolean());
+            Assert.Equal("quality-match", item.GetProperty("status").GetString());
+        }
     }
 }


### PR DESCRIPTION
Small optimization release. I noticed that for users with larger libraries, the library page would take a long time to load. This was due to some redundant and unnecessary checks. Also the the api endpoint was returning a lot of data that was not needed for the page. Additionally I have added url resolution normalizations to download client host/ip:port connection strings so the connection tests are more robust.

## Added
- Shared backend/frontend audiobook status helpers so list views can use a consistent status model without relying on full file metadata from `/library`
- A dedicated slim library list DTO for `GET /library`
- A shared download-client URI builder for normalizing host, scheme, port, and path handling
- Backend regression tests covering:
  - slim `/library` payload behavior
  - wanted-flag correctness
  - NZBGet host normalization and queue-path handling
  - qBittorrent, SABnzbd, and Transmission host normalization

## Changed
- Slimmed `GET /library` from a hybrid list/detail payload into a lighter list response
- Kept `GET /library/{id}` as the rich full-detail audiobook endpoint
- Moved library list status evaluation to shared backend/frontend helpers instead of deriving it ad hoc in views
- Switched the app from timer-based Wanted badge refreshes to store-driven updates backed by existing SignalR events
- Updated the frontend library store to collapse concurrent `/library` requests into a single in-flight fetch
- Reused cached library state for app-shell lookups and related UI flows instead of issuing redundant library requests
- Standardized host/URL interpretation across NZBGet, qBittorrent, SABnzbd, and Transmission for both test/save and runtime monitor paths

## Fixed
- Slow `/library` responses caused by per-audiobook filesystem existence checks during list loading
- Duplicate `/library` requests during startup and view initialization
- Full-library polling churn for the Wanted badge
- Extra DB work in audiobook detail loading by collapsing a two-query existence/fetch path into a single no-tracking query
- NZBGet malformed host parsing that could produce errors like `Name or service not known (http:80)`
- The same malformed host/URL bug class across other download clients when users pasted scheme/path data into host fields

## Removed
- Periodic full-library polling for the Wanted badge
- Per-item filesystem probes from the main `/library` list path
- Redundant client-side dependence on full `files[]` metadata in library list views for status calculation

Continue #401 
