### PR TITLE
Library Optimizations

### DIFF
--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>0.2.58</Version>
-    <AssemblyVersion>0.2.58</AssemblyVersion>
+    <Version>0.2.56</Version>
+    <AssemblyVersion>0.2.56</AssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);bin\**;bin/**;artifacts\**;artifacts/**</DefaultItemExcludes>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>


### PR DESCRIPTION
Small optimization release. I noticed that for users with larger libraries, the library page would take a long time to load. This was due to some redundant and unnecessary checks. Also the the api endpoint was returning a lot of data that was not needed for the page. Additionally I have added url resolution normalizations to download client host/ip:port connection strings so the connection tests are more robust.

## Added
- Shared backend/frontend audiobook status helpers so list views can use a consistent status model without relying on full file metadata from `/library`
- A dedicated slim library list DTO for `GET /library`
- A shared download-client URI builder for normalizing host, scheme, port, and path handling
- Backend regression tests covering:
  - slim `/library` payload behavior
  - wanted-flag correctness
  - NZBGet host normalization and queue-path handling
  - qBittorrent, SABnzbd, and Transmission host normalization

## Changed
- Slimmed `GET /library` from a hybrid list/detail payload into a lighter list response
- Kept `GET /library/{id}` as the rich full-detail audiobook endpoint
- Moved library list status evaluation to shared backend/frontend helpers instead of deriving it ad hoc in views
- Switched the app from timer-based Wanted badge refreshes to store-driven updates backed by existing SignalR events
- Updated the frontend library store to collapse concurrent `/library` requests into a single in-flight fetch
- Reused cached library state for app-shell lookups and related UI flows instead of issuing redundant library requests
- Standardized host/URL interpretation across NZBGet, qBittorrent, SABnzbd, and Transmission for both test/save and runtime monitor paths

## Fixed
- Slow `/library` responses caused by per-audiobook filesystem existence checks during list loading
- Duplicate `/library` requests during startup and view initialization
- Full-library polling churn for the Wanted badge
- Extra DB work in audiobook detail loading by collapsing a two-query existence/fetch path into a single no-tracking query
- NZBGet malformed host parsing that could produce errors like `Name or service not known (http:80)`
- The same malformed host/URL bug class across other download clients when users pasted scheme/path data into host fields

## Removed
- Periodic full-library polling for the Wanted badge
- Per-item filesystem probes from the main `/library` list path
- Redundant client-side dependence on full `files[]` metadata in library list views for status calculation
