### PR TITLE
fix: prevent browser autofill on download client API key field

### DIFF
--- a/fe/src/components/DownloadClientFormModal.vue
+++ b/fe/src/components/DownloadClientFormModal.vue
@@ -90,6 +90,7 @@
                 id="apiKey" 
                 v-model="formData.apiKey" 
                 type="password" 
+                autocomplete="off"
                 required 
                 placeholder="********"
               />


### PR DESCRIPTION
Chrome was prompting to save the API key as a credential. Its not a user password so it shouldnt end up in a password manager.

Added autocomplete="off" to the API key input in DownloadClientFormModal. The service password field is untouched.