### PR TITLE
fix: prevent browser autofill on API key and bot token fields

### DIFF
--- a/fe/src/components/domain/download/DownloadClientFormModal.vue
+++ b/fe/src/components/domain/download/DownloadClientFormModal.vue
@@ -107,6 +107,7 @@
               <PasswordInput
                 id="apiKey"
                 v-model="formData.apiKey"
+                autocomplete="off"
                 placeholder="********"
                 required
                 class="admin-input"

--- a/fe/src/components/settings/IndexerFormModal.vue
+++ b/fe/src/components/settings/IndexerFormModal.vue
@@ -141,7 +141,7 @@
               label="API Key"
               labelFor="apiKey"
             >
-              <PasswordInput id="apiKey" v-model="formData.apiKey" placeholder="Your API key" class="admin-input" />
+              <PasswordInput id="apiKey" v-model="formData.apiKey" autocomplete="off" placeholder="Your API key" class="admin-input" />
             </FormRow>
 
             <FormRow v-if="formData.implementation !== 'InternetArchive'" label="Categories" labelFor="categories" help="Leave empty to search all categories">

--- a/fe/src/views/SettingsView.vue
+++ b/fe/src/views/SettingsView.vue
@@ -256,6 +256,7 @@
               <PasswordInput
                 id="api-key"
                 v-model="apiForm.apiKey"
+                autocomplete="off"
                 placeholder="Optional API key"
               />
               <small>Leave empty if not required</small>

--- a/fe/src/views/settings/DiscordBotTab.vue
+++ b/fe/src/views/settings/DiscordBotTab.vue
@@ -88,6 +88,7 @@
             <input
               :type="showPassword ? 'text' : 'password'"
               v-model="settings.discordBotToken"
+              autocomplete="off"
               placeholder="Bot token (keep secret)"
               class="admin-input password-input"
             />

--- a/fe/src/views/settings/IndexersTab.vue
+++ b/fe/src/views/settings/IndexersTab.vue
@@ -189,6 +189,7 @@
                   <PasswordInput
                     id="prowlarr-key"
                     v-model="prowlarrApiKey"
+                    autocomplete="off"
                     class="form-input"
                     placeholder="Prowlarr API Key"
                   />


### PR DESCRIPTION
Chrome was prompting to save API keys and the Discord bot token as passwords. They arent user credentials so they shouldnt end up in a password manager.

Added autocomplete="off" to the four API key inputs (SettingsView, IndexersTab, DownloadClientFormModal, IndexerFormModal) and the bot token field in DiscordBotTab. Service password fields are untouched -- Chrome can still offer to save those normally.