### PR TITLE
Misc bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Issue-specific regression coverage:** Added focused tests covering qBittorrent auto-import path resolution for both Docker-style remote path mappings and non-Docker local paths, plus authenticated log-download behavior when session login is enabled.
+- **Prowlarr import settings persistence:** Added persisted Prowlarr import connection settings in application settings, including securely stored API key metadata, saved URL/port reuse, saved tag-filter reuse, and focused backend/frontend regression coverage for the new flow.
+
+### Changed
+- **Prowlarr import filtering:** Prowlarr indexer import can now optionally target a specific Prowlarr tag, and when that tag filter is set it overrides the default audiobook-category (`3000/3030`) import behavior.
+- **Prowlarr import modal UX:** Updated the Settings → Indexers → Import from Prowlarr modal to preload saved connection values, allow clearing a previously saved tag override, and close automatically after a successful import.
+- **Wanted manual search table usability:** Kept the manual search download-action column pinned on the right so the action button remains visible while horizontally scrolling wide result tables.
 
 ### Fixed
 - **qBittorrent auto-import path mapping:** Fixed automatic import for completed qBittorrent downloads when `content_path` is already populated, ensuring remote path mappings are still applied before Listenarr checks the source path. This restores Docker-style imports where qBittorrent and Listenarr see different filesystem roots while preserving non-Docker local-path behavior.
 - **Authenticated log downloads:** Fixed `System > Recent Logs > Download Logs` when login is enabled by replacing the unauthenticated `window.open()` flow with an authenticated fetch/blob download path that carries the active session or API auth context.
+- **Intermittent Windows short-path imports:** Fixed existing-book and import-path normalization so sporadic Windows 8.3 short-path aliases no longer leak into stored library paths or imported audiobook locations.
+- **Prowlarr import secret exposure:** Fixed the generic settings-response path so the encrypted saved Prowlarr API key is not returned to the frontend through the broader application settings payload.
 
 ## [0.2.59] - 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.60] - 2026-03-20
+
+### Added
+- **Issue-specific regression coverage:** Added focused tests covering qBittorrent auto-import path resolution for both Docker-style remote path mappings and non-Docker local paths, plus authenticated log-download behavior when session login is enabled.
+
+### Fixed
+- **qBittorrent auto-import path mapping:** Fixed automatic import for completed qBittorrent downloads when `content_path` is already populated, ensuring remote path mappings are still applied before Listenarr checks the source path. This restores Docker-style imports where qBittorrent and Listenarr see different filesystem roots while preserving non-Docker local-path behavior.
+- **Authenticated log downloads:** Fixed `System > Recent Logs > Download Logs` when login is enabled by replacing the unauthenticated `window.open()` flow with an authenticated fetch/blob download path that carries the active session or API auth context.
+
 ## [0.2.59] - 2026-03-19
 
 ### Added

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "listenarr-fe",
-  "version": "0.2.58",
+  "version": "0.2.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "listenarr-fe",
-      "version": "0.2.58",
+      "version": "0.2.59",
       "hasInstallScript": true,
       "dependencies": {
         "@material/material-color-utilities": "^0.4.0",

--- a/fe/package.json
+++ b/fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "listenarr-fe",
-  "version": "0.2.58",
+  "version": "0.2.59",
   "private": true,
   "type": "module",
   "engines": {

--- a/fe/src/__tests__/IndexersTab.spec.ts
+++ b/fe/src/__tests__/IndexersTab.spec.ts
@@ -1,11 +1,14 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 
 // We'll mock getIndexers so we can control its resolution during the test
 describe('IndexersTab', () => {
-  it('shows loading state while fetching indexers', async () => {
+  beforeEach(() => {
     vi.resetModules()
+  })
+
+  it('shows loading state while fetching indexers', async () => {
     const pinia = createPinia()
     setActivePinia(pinia)
 
@@ -17,6 +20,12 @@ describe('IndexersTab', () => {
       return {
         ...(actual as unknown),
         getIndexers: vi.fn(() => new Promise((res) => (resolveFn = res))),
+        getProwlarrImportSettings: vi.fn().mockResolvedValue({
+          url: '',
+          port: undefined,
+          tagFilter: '',
+          hasSavedApiKey: false,
+        }),
       }
     })
 
@@ -45,5 +54,50 @@ describe('IndexersTab', () => {
 
     // After resolution, the empty-state should be shown (no indexers)
     expect(wrapper.find('.empty-state').exists()).toBe(true)
+  })
+
+  it('loads saved Prowlarr connection fields from the API', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+
+    vi.doMock('@/services/api', async (importOriginal) => {
+      const actual = await importOriginal()
+      return {
+        ...(actual as unknown),
+        getIndexers: vi.fn().mockResolvedValue([]),
+        getProwlarrImportSettings: vi.fn().mockResolvedValue({
+          url: 'http://localhost',
+          port: 9696,
+          tagFilter: 'audiobooks',
+          hasSavedApiKey: true,
+        }),
+      }
+    })
+
+    const sr = await import('@/services/signalr')
+    if (!sr.signalRService || typeof sr.signalRService.onIndexersUpdated !== 'function') {
+      ;(sr as unknown).signalRService = { onIndexersUpdated: () => () => {} } as unknown
+    }
+
+    const IndexersTab = (await import('@/views/settings/IndexersTab.vue')).default
+
+    const wrapper = mount(IndexersTab, {
+      attachTo: document.body,
+      global: { plugins: [pinia] },
+    })
+
+    ;(wrapper.vm as unknown as { openProwlarrImport: () => void }).openProwlarrImport()
+    await wrapper.vm.$nextTick()
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await wrapper.vm.$nextTick()
+
+    expect((wrapper.get('#prowlarr-url').element as HTMLInputElement).value).toBe('http://localhost')
+    expect((wrapper.get('#prowlarr-port').element as HTMLInputElement).value).toBe('9696')
+    expect((wrapper.get('#prowlarr-tag-filter').element as HTMLInputElement).value).toBe('audiobooks')
+    expect((wrapper.get('#prowlarr-key').element as HTMLInputElement).value).toBe('')
+    expect(wrapper.text()).toContain('saved API key is already stored securely on the server')
+
+    wrapper.unmount()
   })
 })

--- a/fe/src/__tests__/IndexersTab.spec.ts
+++ b/fe/src/__tests__/IndexersTab.spec.ts
@@ -100,4 +100,58 @@ describe('IndexersTab', () => {
 
     wrapper.unmount()
   })
+
+  it('sends clearPort when the saved Prowlarr port is cleared before import', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+
+    const importProwlarrIndexers = vi.fn().mockResolvedValue({
+      addedCount: 0,
+      skippedCount: 0,
+    })
+
+    vi.doMock('@/services/api', async (importOriginal) => {
+      const actual = await importOriginal()
+      return {
+        ...(actual as unknown),
+        getIndexers: vi.fn().mockResolvedValue([]),
+        getProwlarrImportSettings: vi.fn().mockResolvedValue({
+          url: 'http://localhost',
+          port: 9696,
+          tagFilter: '',
+          hasSavedApiKey: true,
+        }),
+        importProwlarrIndexers,
+      }
+    })
+
+    const sr = await import('@/services/signalr')
+    if (!sr.signalRService || typeof sr.signalRService.onIndexersUpdated !== 'function') {
+      ;(sr as unknown).signalRService = { onIndexersUpdated: () => () => {} } as unknown
+    }
+
+    const IndexersTab = (await import('@/views/settings/IndexersTab.vue')).default
+
+    const wrapper = mount(IndexersTab, {
+      attachTo: document.body,
+      global: { plugins: [pinia] },
+    })
+
+    ;(wrapper.vm as unknown as { openProwlarrImport: () => void }).openProwlarrImport()
+    await wrapper.vm.$nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await wrapper.vm.$nextTick()
+
+    await wrapper.get('#prowlarr-port').setValue('')
+
+    await (wrapper.vm as unknown as { importFromProwlarr: () => Promise<void> }).importFromProwlarr()
+
+    expect(importProwlarrIndexers).toHaveBeenCalledWith({
+      url: 'http://localhost',
+      clearPort: true,
+      tagFilter: '',
+    })
+
+    wrapper.unmount()
+  })
 })

--- a/fe/src/__tests__/IndexersTab.spec.ts
+++ b/fe/src/__tests__/IndexersTab.spec.ts
@@ -154,4 +154,59 @@ describe('IndexersTab', () => {
 
     wrapper.unmount()
   })
+
+  it('handles numeric prowlarrPort state when importing', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+
+    const importProwlarrIndexers = vi.fn().mockResolvedValue({
+      addedCount: 0,
+      skippedCount: 0,
+    })
+
+    vi.doMock('@/services/api', async (importOriginal) => {
+      const actual = await importOriginal()
+      return {
+        ...(actual as unknown),
+        getIndexers: vi.fn().mockResolvedValue([]),
+        getProwlarrImportSettings: vi.fn().mockResolvedValue({
+          url: 'http://localhost',
+          port: 9696,
+          tagFilter: '',
+          hasSavedApiKey: true,
+        }),
+        importProwlarrIndexers,
+      }
+    })
+
+    const sr = await import('@/services/signalr')
+    if (!sr.signalRService || typeof sr.signalRService.onIndexersUpdated !== 'function') {
+      ;(sr as unknown).signalRService = { onIndexersUpdated: () => () => {} } as unknown
+    }
+
+    const IndexersTab = (await import('@/views/settings/IndexersTab.vue')).default
+
+    const wrapper = mount(IndexersTab, {
+      attachTo: document.body,
+      global: { plugins: [pinia] },
+    })
+
+    ;(wrapper.vm as unknown as { openProwlarrImport: () => void }).openProwlarrImport()
+    await wrapper.vm.$nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await wrapper.vm.$nextTick()
+
+    ;(wrapper.vm as unknown as { prowlarrPort: number }).prowlarrPort = 9696
+
+    await (wrapper.vm as unknown as { importFromProwlarr: () => Promise<void> }).importFromProwlarr()
+
+    expect(importProwlarrIndexers).toHaveBeenCalledWith({
+      url: 'http://localhost',
+      port: 9696,
+      clearPort: false,
+      tagFilter: '',
+    })
+
+    wrapper.unmount()
+  })
 })

--- a/fe/src/__tests__/ManualSearchModal.spec.ts
+++ b/fe/src/__tests__/ManualSearchModal.spec.ts
@@ -1,7 +1,33 @@
 import { mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import ManualSearchModal from '@/components/domain/search/ManualSearchModal.vue'
+import * as apiModule from '@/services/api'
+
+const { apiService } = apiModule
+
+if (!(apiService as unknown as Record<string, unknown>).getEnabledIndexers) {
+  ;(apiService as unknown as { getEnabledIndexers: () => Promise<unknown[]> }).getEnabledIndexers =
+    async () => []
+}
+if (!(apiService as unknown as Record<string, unknown>).searchByApi) {
+  ;(apiService as unknown as { searchByApi: () => Promise<unknown[]> }).searchByApi = async () =>
+    []
+}
+if (!(apiService as unknown as Record<string, unknown>).getDefaultQualityProfile) {
+  ;(
+    apiService as unknown as {
+      getDefaultQualityProfile: () => Promise<{ id: number }>
+    }
+  ).getDefaultQualityProfile = async () => ({ id: 1 })
+}
+if (!(apiService as unknown as Record<string, unknown>).scoreSearchResults) {
+  ;(
+    apiService as unknown as {
+      scoreSearchResults: () => Promise<unknown[]>
+    }
+  ).scoreSearchResults = async () => []
+}
 
 type ManualSearchResult = {
   id: string
@@ -59,6 +85,10 @@ describe('ManualSearchModal.vue', () => {
       vm.results = r
     }
   }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
 
   it('uses details page for Usenet title links instead of direct NZB', async () => {
     const wrapper = mount(ManualSearchModal, {
@@ -320,5 +350,61 @@ describe('ManualSearchModal.vue', () => {
     expect(badge.exists()).toBe(true)
     // Normalized components: Quality=90, Format=85, Seed=20 -> avg ~65
     expect(badge.text()).toContain('65')
+  })
+
+  it('loads and attaches score data after search completes', async () => {
+    vi.spyOn(apiService, 'getEnabledIndexers').mockResolvedValue([
+      { id: 1, name: 'Test', implementation: 'Test', additionalSettings: null } as never,
+    ])
+    vi.spyOn(apiService, 'searchByApi').mockResolvedValue([
+      {
+        guid: 'score-result-1',
+        title: 'Scored Result',
+        size: 1024,
+        publishDate: new Date().toISOString(),
+        indexer: 'TestIndexer',
+        indexerId: 1,
+      } as never,
+    ])
+    vi.spyOn(apiService, 'getDefaultQualityProfile').mockResolvedValue({ id: 77 } as never)
+    vi.spyOn(apiService, 'scoreSearchResults').mockImplementation(
+      async (_profileId, searchResults) =>
+        [
+          {
+            searchResult: searchResults[0],
+            totalScore: 88,
+            scoreBreakdown: { Quality: 88 },
+            rejectionReasons: [],
+            isRejected: false,
+          },
+        ] as never,
+    )
+
+    const wrapper = mount(ManualSearchModal, {
+      props: {
+        isOpen: false,
+        audiobook: { id: 99, title: 'Target Book', authors: ['Author Name'] },
+      },
+      global: { stubs },
+    })
+
+    await wrapper.setProps({ isOpen: true })
+
+    const start = Date.now()
+    while (Date.now() - start < 3000) {
+      await nextTick()
+      const badge = wrapper.find('.col-score .score-badge')
+      if (badge.exists() && badge.text().includes('88')) {
+        break
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25))
+    }
+
+    expect(apiService.getDefaultQualityProfile).toHaveBeenCalledTimes(1)
+    expect(apiService.scoreSearchResults).toHaveBeenCalledTimes(1)
+
+    const badge = wrapper.find('.col-score .score-badge')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toContain('88')
   })
 })

--- a/fe/src/__tests__/api.downloadLogs.spec.ts
+++ b/fe/src/__tests__/api.downloadLogs.spec.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.unmock('../services/api')
+
+describe('ApiService.downloadLogs', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('downloads logs through authenticated fetch when session auth is enabled', async () => {
+    vi.resetModules()
+    const { apiService } = await import('../services/api')
+    const { sessionTokenManager } = await import('@/utils/sessionToken')
+
+    sessionTokenManager.setToken('session-token')
+
+    const originalCreateElement = document.createElement.bind(document)
+    const anchor = originalCreateElement('a')
+    const clickSpy = vi.spyOn(anchor, 'click').mockImplementation(() => {})
+    const appendSpy = vi.spyOn(document.body, 'appendChild')
+    const removeSpy = vi.spyOn(document.body, 'removeChild')
+    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName.toLowerCase() === 'a') {
+        return anchor
+      }
+
+      return originalCreateElement(tagName)
+    })
+
+    const createObjectUrlSpy = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:listenarr-download')
+    const revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+
+    const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string> | Headers | undefined
+      const authHeader =
+        headers instanceof Headers ? headers.get('Authorization') : headers?.Authorization
+
+      expect(init?.credentials).toBe('include')
+      expect(authHeader).toBe('Bearer session-token')
+
+      return new Response(new Blob(['log line 1'], { type: 'text/plain' }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/plain',
+          'Content-Disposition': 'attachment; filename="listenarr-test.log"',
+        },
+      })
+    })
+
+    vi.stubGlobal('fetch', fetchSpy)
+
+    await apiService.downloadLogs()
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(createElementSpy).toHaveBeenCalledWith('a')
+    expect(createObjectUrlSpy).toHaveBeenCalledTimes(1)
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    expect(anchor.download).toBe('listenarr-test.log')
+    expect(anchor.href).toBe('blob:listenarr-download')
+    expect(appendSpy).toHaveBeenCalledTimes(1)
+    expect(removeSpy).toHaveBeenCalledTimes(1)
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:listenarr-download')
+
+    sessionTokenManager.clearToken()
+  })
+})

--- a/fe/src/components/domain/search/ManualSearchModal.vue
+++ b/fe/src/components/domain/search/ManualSearchModal.vue
@@ -1026,6 +1026,16 @@ function getScoreClass(score: number): string {
   border-bottom: 2px solid #3a3a3a;
 }
 
+.results-table th.col-actions {
+  position: sticky;
+  right: 0;
+  z-index: 3;
+  background-color: #2a2a2a;
+  box-shadow:
+    -1px 0 0 rgba(255, 255, 255, 0.06),
+    -10px 0 20px rgba(0, 0, 0, 0.22);
+}
+
 .sortable {
   cursor: pointer;
   user-select: none;
@@ -1069,6 +1079,10 @@ function getScoreClass(score: number): string {
   box-shadow: inset 2px 0 0 var(--brand-500);
 }
 
+.results-table tbody tr:hover .col-actions {
+  background-color: rgba(27, 39, 52, 0.96);
+}
+
 /* Remove row background change on hover — underline title text instead */
 .title-text {
   color: white;
@@ -1087,6 +1101,16 @@ function getScoreClass(score: number): string {
   padding: 0.75rem;
   color: #ddd;
   vertical-align: middle;
+}
+
+.results-table td.col-actions {
+  position: sticky;
+  right: 0;
+  z-index: 2;
+  background-color: #1e1e1e;
+  box-shadow:
+    -1px 0 0 rgba(255, 255, 255, 0.06),
+    -10px 0 20px rgba(0, 0, 0, 0.22);
 }
 
 .col-source {

--- a/fe/src/services/api.ts
+++ b/fe/src/services/api.ts
@@ -1684,6 +1684,7 @@ class ApiService {
   async importProwlarrIndexers(payload: {
     url: string
     port?: number
+    clearPort?: boolean
     apiKey?: string
     tagFilter?: string
   }): Promise<{
@@ -2096,7 +2097,7 @@ export const testIndexerDraft = (indexer: Omit<Indexer, 'id' | 'createdAt' | 'up
 export const toggleIndexer = (id: number) => apiService.toggleIndexer(id)
 export const getEnabledIndexers = () => apiService.getEnabledIndexers()
 export const getProwlarrImportSettings = () => apiService.getProwlarrImportSettings()
-export const importProwlarrIndexers = (payload: { url: string; port?: number; apiKey?: string; tagFilter?: string }) =>
+export const importProwlarrIndexers = (payload: { url: string; port?: number; clearPort?: boolean; apiKey?: string; tagFilter?: string }) =>
   apiService.importProwlarrIndexers(payload)
 
 // Export individual remote path mapping functions for convenience

--- a/fe/src/services/api.ts
+++ b/fe/src/services/api.ts
@@ -1762,7 +1762,65 @@ class ApiService {
 
   async downloadLogs(): Promise<void> {
     const url = `${EFFECTIVE_API_BASE}/system/logs/download`
-    window.open(url, '_blank')
+    const headers = this.buildAuthHeaders()
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers,
+      credentials: 'include',
+    })
+
+    if (resp.status === 401) {
+      sessionTokenManager.clearToken()
+      this.antiforgeryToken = null
+      this.antiforgeryTokenSession = null
+      throw Object.assign(new Error('Unauthorized'), { status: 401 })
+    }
+
+    if (!resp.ok) {
+      const contentType = resp.headers.get('content-type') || ''
+      let message = `API error: ${resp.status}`
+
+      if (contentType.includes('application/json')) {
+        const body = await resp.json().catch(() => null) as { message?: string; error?: string } | null
+        const detail = body?.message || body?.error
+        if (detail) {
+          message = detail
+        }
+      } else {
+        const text = await resp.text().catch(() => '')
+        if (text) {
+          message = `API error: ${resp.status} ${text}`
+        }
+      }
+
+      throw Object.assign(new Error(message), { status: resp.status })
+    }
+
+    const contentDisposition = resp.headers.get('content-disposition') || ''
+    let filename = `listenarr-logs-${new Date().toISOString().slice(0, 10)}.log`
+    const match = /filename\*?=(?:UTF-8''|")?([^";]+)"?/i.exec(contentDisposition)
+    if (match?.[1]) {
+      try {
+        filename = decodeURIComponent(match[1])
+      } catch {
+        filename = match[1]
+      }
+    }
+
+    const blob = await resp.blob()
+    const objectUrl = URL.createObjectURL(blob)
+
+    try {
+      const anchor = document.createElement('a')
+      anchor.href = objectUrl
+      anchor.download = filename
+      anchor.style.display = 'none'
+      document.body.appendChild(anchor)
+      anchor.click()
+      document.body.removeChild(anchor)
+    } finally {
+      URL.revokeObjectURL(objectUrl)
+    }
   }
 
   // Quality Profile endpoints

--- a/fe/src/services/api.ts
+++ b/fe/src/services/api.ts
@@ -4,6 +4,7 @@ import type {
   ApiConfiguration,
   DownloadClientConfiguration,
   ApplicationSettings,
+  ProwlarrImportConnectionSettings,
   Audiobook,
   History,
   Indexer,
@@ -868,6 +869,10 @@ class ApiService {
     })
   }
 
+  async getProwlarrImportSettings(): Promise<ProwlarrImportConnectionSettings> {
+    return this.request<ProwlarrImportConnectionSettings>('/configuration/prowlarr-import')
+  }
+
   // Root Folders
   async getRootFolders(): Promise<RootFolder[]> {
     return this.request<RootFolder[]>('/rootfolders')
@@ -1679,7 +1684,8 @@ class ApiService {
   async importProwlarrIndexers(payload: {
     url: string
     port?: number
-    apiKey: string
+    apiKey?: string
+    tagFilter?: string
   }): Promise<{
     addedCount: number
     skippedCount: number
@@ -2089,7 +2095,8 @@ export const testIndexerDraft = (indexer: Omit<Indexer, 'id' | 'createdAt' | 'up
   apiService.testIndexerDraft(indexer)
 export const toggleIndexer = (id: number) => apiService.toggleIndexer(id)
 export const getEnabledIndexers = () => apiService.getEnabledIndexers()
-export const importProwlarrIndexers = (payload: { url: string; port?: number; apiKey: string }) =>
+export const getProwlarrImportSettings = () => apiService.getProwlarrImportSettings()
+export const importProwlarrIndexers = (payload: { url: string; port?: number; apiKey?: string; tagFilter?: string }) =>
   apiService.importProwlarrIndexers(payload)
 
 // Export individual remote path mapping functions for convenience

--- a/fe/src/types/index.ts
+++ b/fe/src/types/index.ts
@@ -322,6 +322,13 @@ export interface ApplicationSettings {
   defaultSearchLanguage?: string
 }
 
+export interface ProwlarrImportConnectionSettings {
+  url: string
+  port?: number
+  tagFilter?: string
+  hasSavedApiKey: boolean
+}
+
 export interface StartupConfig {
   logLevel?: string
   enableSsl?: boolean

--- a/fe/src/views/settings/IndexersTab.vue
+++ b/fe/src/views/settings/IndexersTab.vue
@@ -494,6 +494,7 @@ const importFromProwlarr = async () => {
     const result = await importProwlarrIndexers({
       url,
       port: portValue,
+      clearPort: portRaw.length === 0,
       tagFilter,
       ...(apiKey ? { apiKey } : {}),
     })

--- a/fe/src/views/settings/IndexersTab.vue
+++ b/fe/src/views/settings/IndexersTab.vue
@@ -185,13 +185,34 @@
                   />
                 </FormRow>
 
-                <FormRow label="API Key" labelFor="prowlarr-key" help="Find this in Prowlarr Settings → General">
+                <FormRow
+                  label="Tag Filter (optional)"
+                  labelFor="prowlarr-tag-filter"
+                  help="Only import indexers with this Prowlarr tag. When set, this overrides the default audiobook category import."
+                >
+                  <input
+                    id="prowlarr-tag-filter"
+                    v-model="prowlarrTagFilter"
+                    type="text"
+                    class="form-input"
+                    placeholder="audiobooks"
+                    autocomplete="off"
+                  />
+                </FormRow>
+
+                <FormRow
+                  label="API Key"
+                  labelFor="prowlarr-key"
+                  :help="hasSavedProwlarrApiKey
+                    ? 'A saved API key is already stored securely on the server. Leave this blank to reuse it, or enter a new key to replace it.'
+                    : 'Find this in Prowlarr Settings → General'"
+                >
                   <PasswordInput
                     id="prowlarr-key"
                     v-model="prowlarrApiKey"
                     autocomplete="off"
                     class="form-input"
-                    placeholder="Prowlarr API Key"
+                    :placeholder="hasSavedProwlarrApiKey ? 'Leave blank to use saved API key' : 'Prowlarr API Key'"
                   />
                 </FormRow>
               </FormSection>
@@ -261,6 +282,7 @@ import {
   toggleIndexer as apiToggleIndexer,
   testIndexer as apiTestIndexer,
   deleteIndexer,
+  getProwlarrImportSettings,
   importProwlarrIndexers,
 } from '@/services/api'
 import { signalRService } from '@/services/signalr'
@@ -279,7 +301,9 @@ const lastTestResults = reactive<Record<number, 'success' | 'fail' | undefined>>
 // Prowlarr import state
 const prowlarrUrl = ref('')
 const prowlarrPort = ref('')
+const prowlarrTagFilter = ref('')
 const prowlarrApiKey = ref('')
+const hasSavedProwlarrApiKey = ref(false)
 const importingProwlarr = ref(false)
 const prowlarrSummary = ref<{ addedCount: number; skippedCount: number } | null>(null)
 const showProwlarrModal = ref(false)
@@ -411,7 +435,24 @@ const executeDeleteIndexer = async () => {
   }
 }
 
+const loadProwlarrImportSettings = async () => {
+  try {
+    const saved = await getProwlarrImportSettings()
+    prowlarrUrl.value = saved.url ?? ''
+    prowlarrPort.value = saved.port != null ? String(saved.port) : ''
+    prowlarrTagFilter.value = saved.tagFilter ?? ''
+    hasSavedProwlarrApiKey.value = saved.hasSavedApiKey === true
+    prowlarrApiKey.value = ''
+  } catch (error) {
+    errorTracking.captureException(error as Error, {
+      component: 'IndexersTab',
+      operation: 'loadProwlarrImportSettings',
+    })
+  }
+}
+
 const openProwlarrModal = () => {
+  void loadProwlarrImportSettings()
   showProwlarrModal.value = true
 }
 
@@ -424,13 +465,14 @@ const importFromProwlarr = async () => {
   const url = prowlarrUrl.value.trim()
   const apiKey = prowlarrApiKey.value.trim()
   const portRaw = prowlarrPort.value.trim()
+  const tagFilter = prowlarrTagFilter.value.trim()
 
   if (!url) {
     toast.warning('Prowlarr', 'Please enter a Prowlarr URL or IP')
     return
   }
 
-  if (!apiKey) {
+  if (!apiKey && !hasSavedProwlarrApiKey.value) {
     toast.warning('Prowlarr', 'Please enter your Prowlarr API key')
     return
   }
@@ -452,7 +494,8 @@ const importFromProwlarr = async () => {
     const result = await importProwlarrIndexers({
       url,
       port: portValue,
-      apiKey,
+      tagFilter,
+      ...(apiKey ? { apiKey } : {}),
     })
 
     prowlarrSummary.value = {
@@ -460,14 +503,17 @@ const importFromProwlarr = async () => {
       skippedCount: result.skippedCount,
     }
 
+    await loadProwlarrImportSettings()
     await loadIndexers()
     toast.success('Prowlarr', `Imported ${result.addedCount} indexer(s)`)
+    closeProwlarrModal()
   } catch (error) {
     errorTracking.captureException(error as Error, {
       component: 'IndexersTab',
       operation: 'importProwlarrIndexers',
     })
     const errorMessage = formatApiError(error)
+    await loadProwlarrImportSettings()
     toast.error('Prowlarr import failed', errorMessage)
   } finally {
     importingProwlarr.value = false
@@ -483,6 +529,7 @@ function isNew(id: number) {
 
 onMounted(() => {
   loadIndexers()
+  void loadProwlarrImportSettings()
   // Subscribe to IndexersUpdated messages so external changes (eg. Prowlarr sync) refresh the list
   const unsub = signalRService.onIndexersUpdated((payload) => {
     const payloadIndexers = Array.isArray(payload?.indexers)

--- a/fe/src/views/settings/IndexersTab.vue
+++ b/fe/src/views/settings/IndexersTab.vue
@@ -464,7 +464,7 @@ const closeProwlarrModal = () => {
 const importFromProwlarr = async () => {
   const url = prowlarrUrl.value.trim()
   const apiKey = prowlarrApiKey.value.trim()
-  const portRaw = prowlarrPort.value.trim()
+  const portRaw = String(prowlarrPort.value ?? '').trim()
   const tagFilter = prowlarrTagFilter.value.trim()
 
   if (!url) {

--- a/listenarr.api/Controllers/ConfigurationController.cs
+++ b/listenarr.api/Controllers/ConfigurationController.cs
@@ -21,6 +21,7 @@ using Listenarr.Api.Services;
 using Listenarr.Api.Hubs;
 using Microsoft.AspNetCore.Mvc;
 using System.Linq;
+using System.Text.Json;
 using Microsoft.AspNetCore.SignalR;
 
 namespace Listenarr.Api.Controllers
@@ -386,7 +387,7 @@ namespace Listenarr.Api.Controllers
         {
             try
             {
-                var settings = await _configurationService.GetApplicationSettingsAsync();
+                var settings = PrepareApplicationSettingsResponse(await _configurationService.GetApplicationSettingsAsync());
                 if (SecurityRequestUtils.ShouldRedactSecretsForCaller(HttpContext))
                 {
                     return Ok(ApiResponseRedactor.RedactApplicationSettings(settings));
@@ -414,7 +415,7 @@ namespace Listenarr.Api.Controllers
                 await _configurationService.SaveApplicationSettingsAsync(settings);
 
                 // Return the saved settings to confirm what was persisted
-                var savedSettings = await _configurationService.GetApplicationSettingsAsync();
+                var savedSettings = PrepareApplicationSettingsResponse(await _configurationService.GetApplicationSettingsAsync());
 
                 // Clear sensitive admin credentials from response (they are [NotMapped] but let's be safe)
                 savedSettings.AdminUsername = null;
@@ -434,6 +435,37 @@ namespace Listenarr.Api.Controllers
             catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) {
                 _logger.LogError(ex, "Error saving application settings");
                 return StatusCode(500, new { error = "Failed to save application settings", message = ex.Message });
+            }
+        }
+
+        private static ApplicationSettings PrepareApplicationSettingsResponse(ApplicationSettings settings)
+        {
+            var clone = JsonSerializer.Deserialize<ApplicationSettings>(JsonSerializer.Serialize(settings))
+                ?? new ApplicationSettings();
+            clone.AdminUsername = null;
+            clone.AdminPassword = null;
+            clone.ProwlarrApiKeyEncrypted = null;
+            return clone;
+        }
+
+        /// <summary>
+        /// Get the saved Prowlarr import connection metadata used by the Indexers tab.
+        /// The API key itself is never returned; callers only receive whether a saved key exists.
+        /// </summary>
+        [Tags("Settings")]
+        [HttpGet("prowlarr-import")]
+        public async Task<ActionResult<ProwlarrImportConnectionSettings>> GetProwlarrImportSettings()
+        {
+            try
+            {
+                var settings = await _configurationService.GetProwlarrImportSettingsAsync();
+                settings.ApiKey = null;
+                return Ok(settings);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogError(ex, "Error retrieving saved Prowlarr import settings");
+                return StatusCode(500, "Internal server error");
             }
         }
 

--- a/listenarr.api/Controllers/IndexersController.cs
+++ b/listenarr.api/Controllers/IndexersController.cs
@@ -39,13 +39,15 @@ namespace Listenarr.Api.Controllers
         private readonly ILogger<IndexersController> _logger;
         private readonly HttpClient _httpClient;
         private readonly HttpClient _httpClientNoRedirect;
+        private readonly IConfigurationService _configurationService;
 
-        public IndexersController(ListenArrDbContext dbContext, ILogger<IndexersController> logger, HttpClient httpClient)
+        public IndexersController(ListenArrDbContext dbContext, ILogger<IndexersController> logger, HttpClient httpClient, IConfigurationService configurationService)
         {
             _dbContext = dbContext;
             _logger = logger;
             _httpClient = httpClient;
             _httpClientNoRedirect = httpClient;
+            _configurationService = configurationService;
         }
 
         private bool ShouldRedactIndexerSecretsForCaller()
@@ -393,7 +395,9 @@ namespace Listenarr.Api.Controllers
         }
 
         /// <summary>
-        /// Import audiobook-related indexers (category 3000/3030) from a Prowlarr instance.
+        /// Import indexers from a Prowlarr instance.
+        /// By default this imports audiobook-related indexers (category 3000/3030),
+        /// but a configured tag filter overrides that selection.
         /// </summary>
         /// <param name="request">Prowlarr server URL and API key.</param>
         [HttpPost("prowlarr/import")]
@@ -404,27 +408,43 @@ namespace Listenarr.Api.Controllers
                 return BadRequest(new { message = "Request body is required" });
             }
 
-            if (string.IsNullOrWhiteSpace(request.Url))
+            var savedConnection = await _configurationService.GetProwlarrImportSettingsAsync(includeSecret: true);
+            var effectiveUrl = string.IsNullOrWhiteSpace(request.Url) ? savedConnection.Url : request.Url.Trim();
+            var effectivePort = request.Port ?? savedConnection.Port;
+            var effectiveApiKey = string.IsNullOrWhiteSpace(request.ApiKey) ? savedConnection.ApiKey : request.ApiKey.Trim();
+            var effectiveTagFilter = request.TagFilter == null
+                ? savedConnection.TagFilter?.Trim()
+                : request.TagFilter.Trim();
+
+            if (string.IsNullOrWhiteSpace(effectiveUrl))
             {
                 return BadRequest(new { message = "Prowlarr URL is required" });
             }
 
-            if (string.IsNullOrWhiteSpace(request.ApiKey))
+            if (string.IsNullOrWhiteSpace(effectiveApiKey))
             {
                 return BadRequest(new { message = "Prowlarr API key is required" });
             }
 
-            var baseUrl = BuildProwlarrBaseUrl(request.Url, request.Port);
+            var baseUrl = BuildProwlarrBaseUrl(effectiveUrl, effectivePort);
             var blockedBaseUrlReason = await ValidateOutboundUrlForCallerAsync(baseUrl);
             if (!string.IsNullOrWhiteSpace(blockedBaseUrlReason))
             {
                 return BadRequest(new { message = $"Blocked Prowlarr target: {blockedBaseUrlReason}" });
             }
+
+            await _configurationService.SaveProwlarrImportSettingsAsync(new ProwlarrImportConnectionSettings
+            {
+                Url = effectiveUrl,
+                Port = effectivePort,
+                ApiKey = string.IsNullOrWhiteSpace(request.ApiKey) ? null : request.ApiKey.Trim(),
+                TagFilter = effectiveTagFilter,
+            });
             HttpResponseMessage response;
             string payload;
             try
             {
-                (response, payload) = await FetchProwlarrIndexersAsync(baseUrl, request.ApiKey.Trim());
+                (response, payload) = await FetchProwlarrIndexersAsync(baseUrl, effectiveApiKey.Trim());
             }
             catch (HttpRequestException ex)
             {
@@ -461,6 +481,12 @@ namespace Listenarr.Api.Controllers
             var existingIndexers = await _dbContext.Indexers.AsNoTracking().ToListAsync();
             var createdIndexers = new List<Indexer>();
             var skipped = 0;
+            Dictionary<string, string>? tagMap = null;
+
+            if (!string.IsNullOrWhiteSpace(effectiveTagFilter))
+            {
+                tagMap = await TryFetchProwlarrTagMapAsync(baseUrl, effectiveApiKey.Trim());
+            }
 
             foreach (var element in doc.RootElement.EnumerateArray())
             {
@@ -472,7 +498,12 @@ namespace Listenarr.Api.Controllers
 
                 var indexerId = idProp.GetInt32();
                 var categoryIds = GetCategoryIdsFromProwlarrIndexer(element);
-                if (!categoryIds.Contains(3000) && !categoryIds.Contains(3030))
+                var prowlarrTags = GetProwlarrTagValues(element, tagMap);
+                var matchesImportFilter = string.IsNullOrWhiteSpace(effectiveTagFilter)
+                    ? categoryIds.Contains(3000) || categoryIds.Contains(3030)
+                    : prowlarrTags.Any(tag => string.Equals(tag, effectiveTagFilter, StringComparison.OrdinalIgnoreCase));
+
+                if (!matchesImportFilter)
                 {
                     skipped++;
                     continue;
@@ -498,7 +529,7 @@ namespace Listenarr.Api.Controllers
                 var exists = existingIndexers.FirstOrDefault(i =>
                     NormalizeProwlarrProxyUrl(i.Url) == normalizedUrl &&
                     string.Equals(i.Implementation, implementation, StringComparison.OrdinalIgnoreCase) &&
-                    string.Equals(i.ApiKey ?? string.Empty, request.ApiKey ?? string.Empty, StringComparison.Ordinal));
+                    string.Equals(i.ApiKey ?? string.Empty, effectiveApiKey ?? string.Empty, StringComparison.Ordinal));
 
                 if (exists != null)
                 {
@@ -525,7 +556,7 @@ namespace Listenarr.Api.Controllers
                     Type = type,
                     Implementation = implementation,
                     Url = normalizedUrl,
-                    ApiKey = string.IsNullOrWhiteSpace(request.ApiKey) ? null : request.ApiKey.Trim(),
+                    ApiKey = string.IsNullOrWhiteSpace(effectiveApiKey) ? null : effectiveApiKey.Trim(),
                     Categories = categories,
                     EnableRss = true,
                     EnableAutomaticSearch = true,
@@ -1226,6 +1257,170 @@ namespace Listenarr.Api.Controllers
             }
 
             return (lastResponse ?? new HttpResponseMessage(System.Net.HttpStatusCode.BadGateway), lastPayload);
+        }
+
+        private async Task<Dictionary<string, string>?> TryFetchProwlarrTagMapAsync(string baseUrl, string apiKey)
+        {
+            try
+            {
+                var encodedKey = System.Net.WebUtility.UrlEncode(apiKey);
+                var endpoints = new List<string>
+                {
+                    $"{baseUrl}/api/v1/tag",
+                    $"{baseUrl}/api/v1/tag?apikey={encodedKey}"
+                };
+
+                foreach (var endpoint in endpoints)
+                {
+                    using var response = await SendValidatedAsync(currentUri =>
+                    {
+                        var retryRequest = new HttpRequestMessage(HttpMethod.Get, currentUri);
+                        retryRequest.Headers.Add("X-Api-Key", apiKey);
+                        return retryRequest;
+                    }, endpoint);
+
+                    var body = await response.Content.ReadAsStringAsync();
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        if (response.StatusCode != System.Net.HttpStatusCode.MethodNotAllowed &&
+                            response.StatusCode != System.Net.HttpStatusCode.Unauthorized &&
+                            response.StatusCode != System.Net.HttpStatusCode.Forbidden)
+                        {
+                            break;
+                        }
+
+                        continue;
+                    }
+
+                    using var doc = JsonDocument.Parse(body);
+                    if (doc.RootElement.ValueKind != JsonValueKind.Array)
+                    {
+                        return null;
+                    }
+
+                    var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var tag in doc.RootElement.EnumerateArray())
+                    {
+                        if (!tag.TryGetProperty("id", out var idProp) || idProp.ValueKind != JsonValueKind.Number)
+                        {
+                            continue;
+                        }
+
+                        var id = idProp.GetInt32().ToString();
+                        var label =
+                            tag.TryGetProperty("label", out var labelProp) && labelProp.ValueKind == JsonValueKind.String
+                                ? labelProp.GetString()
+                                : tag.TryGetProperty("name", out var nameProp) && nameProp.ValueKind == JsonValueKind.String
+                                    ? nameProp.GetString()
+                                    : null;
+
+                        if (!string.IsNullOrWhiteSpace(label))
+                        {
+                            result[id] = label.Trim();
+                        }
+                    }
+
+                    return result;
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogWarning(ex, "Failed to load Prowlarr tags from {Url}", LogRedaction.SanitizeUrl(baseUrl));
+            }
+
+            return null;
+        }
+
+        private static HashSet<string> GetProwlarrTagValues(JsonElement element, IReadOnlyDictionary<string, string>? tagMap)
+        {
+            var tags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (element.TryGetProperty("tags", out var rawTags))
+            {
+                AddTagValues(rawTags, tags, tagMap);
+            }
+
+            if (element.TryGetProperty("tagNames", out var tagNames))
+            {
+                AddTagValues(tagNames, tags, tagMap);
+            }
+
+            if (element.TryGetProperty("fields", out var fields) && fields.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var field in fields.EnumerateArray())
+                {
+                    if (!field.TryGetProperty("name", out var nameProp) || nameProp.ValueKind != JsonValueKind.String)
+                    {
+                        continue;
+                    }
+
+                    var fieldName = nameProp.GetString();
+                    if (!string.Equals(fieldName, "tags", StringComparison.OrdinalIgnoreCase) &&
+                        !string.Equals(fieldName, "tagNames", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    if (field.TryGetProperty("value", out var valueProp))
+                    {
+                        AddTagValues(valueProp, tags, tagMap);
+                    }
+                }
+            }
+
+            return tags;
+        }
+
+        private static void AddTagValues(JsonElement value, HashSet<string> tags, IReadOnlyDictionary<string, string>? tagMap)
+        {
+            switch (value.ValueKind)
+            {
+                case JsonValueKind.String:
+                    foreach (var part in value.GetString()?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? Array.Empty<string>())
+                    {
+                        AddTagValue(part, tags, tagMap);
+                    }
+                    break;
+                case JsonValueKind.Number:
+                    AddTagValue(value.ToString(), tags, tagMap);
+                    break;
+                case JsonValueKind.Array:
+                    foreach (var item in value.EnumerateArray())
+                    {
+                        AddTagValues(item, tags, tagMap);
+                    }
+                    break;
+                case JsonValueKind.Object:
+                    if (value.TryGetProperty("label", out var labelProp) && labelProp.ValueKind == JsonValueKind.String)
+                    {
+                        AddTagValue(labelProp.GetString(), tags, tagMap);
+                    }
+                    else if (value.TryGetProperty("name", out var nameProp) && nameProp.ValueKind == JsonValueKind.String)
+                    {
+                        AddTagValue(nameProp.GetString(), tags, tagMap);
+                    }
+                    else if (value.TryGetProperty("id", out var idProp) && idProp.ValueKind == JsonValueKind.Number)
+                    {
+                        AddTagValue(idProp.GetInt32().ToString(), tags, tagMap);
+                    }
+                    break;
+            }
+        }
+
+        private static void AddTagValue(string? rawValue, HashSet<string> tags, IReadOnlyDictionary<string, string>? tagMap)
+        {
+            if (string.IsNullOrWhiteSpace(rawValue))
+            {
+                return;
+            }
+
+            var trimmed = rawValue.Trim();
+            tags.Add(trimmed);
+
+            if (tagMap != null && tagMap.TryGetValue(trimmed, out var label) && !string.IsNullOrWhiteSpace(label))
+            {
+                tags.Add(label.Trim());
+            }
         }
 
         private static string? GetFieldStringValue(JsonElement element, string fieldName)

--- a/listenarr.api/Controllers/IndexersController.cs
+++ b/listenarr.api/Controllers/IndexersController.cs
@@ -1438,15 +1438,7 @@ namespace Listenarr.Api.Controllers
                 return false;
             }
 
-            foreach (var element in payload.EnumerateArray())
-            {
-                if (ElementRequiresProwlarrTagMap(element))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return payload.EnumerateArray().Any(ElementRequiresProwlarrTagMap);
         }
 
         private static bool ElementRequiresProwlarrTagMap(JsonElement element)

--- a/listenarr.api/Controllers/IndexersController.cs
+++ b/listenarr.api/Controllers/IndexersController.cs
@@ -433,13 +433,6 @@ namespace Listenarr.Api.Controllers
                 return BadRequest(new { message = $"Blocked Prowlarr target: {blockedBaseUrlReason}" });
             }
 
-            await _configurationService.SaveProwlarrImportSettingsAsync(new ProwlarrImportConnectionSettings
-            {
-                Url = effectiveUrl,
-                Port = effectivePort,
-                ApiKey = string.IsNullOrWhiteSpace(request.ApiKey) ? null : request.ApiKey.Trim(),
-                TagFilter = effectiveTagFilter,
-            });
             HttpResponseMessage response;
             string payload;
             try
@@ -477,6 +470,14 @@ namespace Listenarr.Api.Controllers
             {
                 return StatusCode(502, new { message = "Unexpected Prowlarr API response" });
             }
+
+            await _configurationService.SaveProwlarrImportSettingsAsync(new ProwlarrImportConnectionSettings
+            {
+                Url = effectiveUrl,
+                Port = effectivePort,
+                ApiKey = string.IsNullOrWhiteSpace(request.ApiKey) ? null : request.ApiKey.Trim(),
+                TagFilter = effectiveTagFilter,
+            });
 
             var existingIndexers = await _dbContext.Indexers.AsNoTracking().ToListAsync();
             var createdIndexers = new List<Indexer>();

--- a/listenarr.api/Controllers/IndexersController.cs
+++ b/listenarr.api/Controllers/IndexersController.cs
@@ -410,7 +410,7 @@ namespace Listenarr.Api.Controllers
 
             var savedConnection = await _configurationService.GetProwlarrImportSettingsAsync(includeSecret: true);
             var effectiveUrl = string.IsNullOrWhiteSpace(request.Url) ? savedConnection.Url : request.Url.Trim();
-            var effectivePort = request.Port ?? savedConnection.Port;
+            var effectivePort = request.ClearPort ? null : request.Port ?? savedConnection.Port;
             var effectiveApiKey = string.IsNullOrWhiteSpace(request.ApiKey) ? savedConnection.ApiKey : request.ApiKey.Trim();
             var effectiveTagFilter = request.TagFilter == null
                 ? savedConnection.TagFilter?.Trim()
@@ -487,6 +487,13 @@ namespace Listenarr.Api.Controllers
             if (!string.IsNullOrWhiteSpace(effectiveTagFilter))
             {
                 tagMap = await TryFetchProwlarrTagMapAsync(baseUrl, effectiveApiKey.Trim());
+                if ((tagMap == null || tagMap.Count == 0) && PayloadRequiresProwlarrTagMap(doc.RootElement))
+                {
+                    _logger.LogWarning(
+                        "Prowlarr tag-filtered import for {Url} requires tag label lookup, but tags could not be loaded",
+                        LogRedaction.SanitizeUrl(baseUrl));
+                    return StatusCode(502, new { message = "Failed to load Prowlarr tags required for tag-filtered import" });
+                }
             }
 
             foreach (var element in doc.RootElement.EnumerateArray())
@@ -1421,6 +1428,122 @@ namespace Listenarr.Api.Controllers
             if (tagMap != null && tagMap.TryGetValue(trimmed, out var label) && !string.IsNullOrWhiteSpace(label))
             {
                 tags.Add(label.Trim());
+            }
+        }
+
+        private static bool PayloadRequiresProwlarrTagMap(JsonElement payload)
+        {
+            if (payload.ValueKind != JsonValueKind.Array)
+            {
+                return false;
+            }
+
+            foreach (var element in payload.EnumerateArray())
+            {
+                if (ElementRequiresProwlarrTagMap(element))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool ElementRequiresProwlarrTagMap(JsonElement element)
+        {
+            var hasTagData = false;
+            var hasTextualTagData = false;
+
+            if (element.TryGetProperty("tags", out var rawTags))
+            {
+                InspectProwlarrTagValue(rawTags, ref hasTagData, ref hasTextualTagData);
+            }
+
+            if (element.TryGetProperty("tagNames", out var tagNames))
+            {
+                InspectProwlarrTagValue(tagNames, ref hasTagData, ref hasTextualTagData);
+            }
+
+            if (element.TryGetProperty("fields", out var fields) && fields.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var field in fields.EnumerateArray())
+                {
+                    if (!field.TryGetProperty("name", out var nameProp) || nameProp.ValueKind != JsonValueKind.String)
+                    {
+                        continue;
+                    }
+
+                    var fieldName = nameProp.GetString();
+                    if (!string.Equals(fieldName, "tags", StringComparison.OrdinalIgnoreCase) &&
+                        !string.Equals(fieldName, "tagNames", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    if (field.TryGetProperty("value", out var valueProp))
+                    {
+                        InspectProwlarrTagValue(valueProp, ref hasTagData, ref hasTextualTagData);
+                    }
+                }
+            }
+
+            return hasTagData && !hasTextualTagData;
+        }
+
+        private static void InspectProwlarrTagValue(JsonElement value, ref bool hasTagData, ref bool hasTextualTagData)
+        {
+            switch (value.ValueKind)
+            {
+                case JsonValueKind.String:
+                    foreach (var part in value.GetString()?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? Array.Empty<string>())
+                    {
+                        InspectProwlarrTagToken(part, ref hasTagData, ref hasTextualTagData);
+                    }
+                    break;
+                case JsonValueKind.Number:
+                    hasTagData = true;
+                    break;
+                case JsonValueKind.Array:
+                    foreach (var item in value.EnumerateArray())
+                    {
+                        InspectProwlarrTagValue(item, ref hasTagData, ref hasTextualTagData);
+                    }
+                    break;
+                case JsonValueKind.Object:
+                    if (value.TryGetProperty("label", out var labelProp) && labelProp.ValueKind == JsonValueKind.String)
+                    {
+                        InspectProwlarrTagToken(labelProp.GetString(), ref hasTagData, ref hasTextualTagData);
+                    }
+                    else if (value.TryGetProperty("name", out var nameProp) && nameProp.ValueKind == JsonValueKind.String)
+                    {
+                        InspectProwlarrTagToken(nameProp.GetString(), ref hasTagData, ref hasTextualTagData);
+                    }
+                    else if (value.TryGetProperty("id", out var idProp))
+                    {
+                        if (idProp.ValueKind == JsonValueKind.Number)
+                        {
+                            hasTagData = true;
+                        }
+                        else if (idProp.ValueKind == JsonValueKind.String)
+                        {
+                            InspectProwlarrTagToken(idProp.GetString(), ref hasTagData, ref hasTextualTagData);
+                        }
+                    }
+                    break;
+            }
+        }
+
+        private static void InspectProwlarrTagToken(string? rawValue, ref bool hasTagData, ref bool hasTextualTagData)
+        {
+            if (string.IsNullOrWhiteSpace(rawValue))
+            {
+                return;
+            }
+
+            hasTagData = true;
+            if (!long.TryParse(rawValue.Trim(), out _))
+            {
+                hasTextualTagData = true;
             }
         }
 

--- a/listenarr.api/Controllers/LibraryController.cs
+++ b/listenarr.api/Controllers/LibraryController.cs
@@ -457,7 +457,7 @@ namespace Listenarr.Api.Controllers
             {
                 // User provided a custom destination path - store it as BasePath
                 // ImportService will recognize BasePath as set and use filename-only pattern
-                audiobook.BasePath = request.DestinationPath;
+                audiobook.BasePath = FileUtils.NormalizeStoredPath(request.DestinationPath);
                 _logger.LogInformation("Using custom destination path for audiobook '{Title}': {BasePath}",
                     audiobook.Title, audiobook.BasePath);
             }
@@ -1627,7 +1627,7 @@ namespace Listenarr.Api.Controllers
             // Allow updating BasePath (destination) from the frontend when provided
             if (updatedAudiobook.BasePath != null)
             {
-                existingAudiobook.BasePath = updatedAudiobook.BasePath;
+                existingAudiobook.BasePath = FileUtils.NormalizeStoredPath(updatedAudiobook.BasePath);
                 _logger.LogInformation("Updated BasePath for audiobook '{Title}' to: {BasePath}", LogRedaction.SanitizeText(existingAudiobook.Title), LogRedaction.SanitizeFilePath(updatedAudiobook.BasePath));
             }
 
@@ -2235,7 +2235,7 @@ namespace Listenarr.Api.Controllers
 
             try
             {
-                return Path.GetFullPath(path)
+                return FileUtils.NormalizeStoredPath(path)
                     .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
             }
             catch
@@ -3926,7 +3926,11 @@ namespace Listenarr.Api.Controllers
                 return string.Empty;
 
             // Convert all paths to directory paths (get parent directory for each file)
-            var directories = filePaths.Select(p => Path.GetDirectoryName(p) ?? p).Distinct().ToList();
+            var directories = filePaths
+                .Select(p => FileUtils.NormalizeStoredPath(Path.GetDirectoryName(p) ?? p))
+                .Where(p => !string.IsNullOrWhiteSpace(p))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
             if (directories.Count == 1)
             {
@@ -3980,11 +3984,12 @@ namespace Listenarr.Api.Controllers
             if (!paths.Any())
                 return string.Empty;
 
-            var firstPath = paths[0];
+            var firstPath = FileUtils.NormalizeStoredPath(paths[0]);
             var commonPath = firstPath;
 
-            foreach (var path in paths.Skip(1))
+            foreach (var rawPath in paths.Skip(1))
             {
+                var path = FileUtils.NormalizeStoredPath(rawPath);
                 var minLength = Math.Min(commonPath.Length, path.Length);
                 var commonLength = 0;
 

--- a/listenarr.api/Controllers/ManualImportController.cs
+++ b/listenarr.api/Controllers/ManualImportController.cs
@@ -266,7 +266,7 @@ public class ManualImportController : ControllerBase
                 }
 
                 // Use fallback path
-                audiobook.BasePath = fallbackPath;
+                audiobook.BasePath = FileUtils.NormalizeStoredPath(fallbackPath);
             }
 
             // Extract metadata from the file
@@ -439,11 +439,17 @@ public class ManualImportController : ControllerBase
 
             var normalizedCurrent = string.IsNullOrWhiteSpace(audiobook.BasePath)
                 ? string.Empty
-                : Path.GetFullPath(audiobook.BasePath);
-            var normalizedScanPath = Path.GetFullPath(scanPath);
+                : FileUtils.NormalizeStoredPath(audiobook.BasePath);
+            var normalizedScanPath = FileUtils.NormalizeStoredPath(scanPath);
 
             if (string.Equals(normalizedCurrent, normalizedScanPath, StringComparison.OrdinalIgnoreCase))
             {
+                if (!string.Equals(audiobook.BasePath, normalizedScanPath, StringComparison.Ordinal))
+                {
+                    audiobook.BasePath = normalizedScanPath;
+                    await _audiobookRepository.UpdateAsync(audiobook);
+                }
+
                 return;
             }
 
@@ -477,14 +483,16 @@ public class ManualImportController : ControllerBase
         // root folder), store directly under that path using file-only naming.
         // If BasePath IS a configured root folder, treat it as a library destination and
         // apply the full folder+file naming pattern so files are properly organised.
-        var basePath = audiobook.BasePath ?? string.Empty;
+        var basePath = string.IsNullOrWhiteSpace(audiobook.BasePath)
+            ? string.Empty
+            : FileUtils.NormalizeStoredPath(audiobook.BasePath);
         var configuredOutput = settings.OutputPath ?? string.Empty;
         var isCustomBasePath = false;
         try
         {
             if (!string.IsNullOrWhiteSpace(basePath))
             {
-                var baseFull = Path.GetFullPath(basePath);
+                var baseFull = FileUtils.NormalizeStoredPath(basePath);
                 var configuredFull = string.IsNullOrWhiteSpace(configuredOutput) ? string.Empty : Path.GetFullPath(configuredOutput);
                 isCustomBasePath = !string.Equals(baseFull, configuredFull, StringComparison.OrdinalIgnoreCase);
 
@@ -495,7 +503,7 @@ public class ManualImportController : ControllerBase
                     var rootFolders = await _rootFolderService.GetAllAsync();
                     var isRootFolder = rootFolders.Any(r =>
                     {
-                        try { return string.Equals(Path.GetFullPath(r.Path), baseFull, StringComparison.OrdinalIgnoreCase); }
+                        try { return string.Equals(FileUtils.NormalizeStoredPath(r.Path), baseFull, StringComparison.OrdinalIgnoreCase); }
                         catch { return false; }
                     });
                     if (isRootFolder) isCustomBasePath = false;
@@ -635,7 +643,7 @@ public class ManualImportController : ControllerBase
         string? associationBasePath;
         try
         {
-            associationBasePath = Path.GetDirectoryName(Path.GetFullPath(destinationPath));
+            associationBasePath = Path.GetDirectoryName(FileUtils.NormalizeStoredPath(destinationPath));
         }
         catch
         {
@@ -651,10 +659,17 @@ public class ManualImportController : ControllerBase
         {
             try
             {
-                var normalizedCurrent = Path.GetFullPath(audiobook.BasePath);
-                if (string.Equals(normalizedCurrent, associationBasePath, StringComparison.OrdinalIgnoreCase)
-                    || FileUtils.IsPathWithinRoot(destinationPath, normalizedCurrent))
+                var normalizedCurrent = FileUtils.NormalizeStoredPath(audiobook.BasePath);
+                var matchesCurrent = string.Equals(normalizedCurrent, associationBasePath, StringComparison.OrdinalIgnoreCase);
+                var destinationWithinCurrent = FileUtils.IsPathWithinRoot(destinationPath, normalizedCurrent);
+                if (matchesCurrent || destinationWithinCurrent)
                 {
+                    if (!string.Equals(audiobook.BasePath, normalizedCurrent, StringComparison.Ordinal))
+                    {
+                        audiobook.BasePath = normalizedCurrent;
+                        await _audiobookRepository.UpdateAsync(audiobook);
+                    }
+
                     return;
                 }
             }

--- a/listenarr.api/Models/ProwlarrImportRequest.cs
+++ b/listenarr.api/Models/ProwlarrImportRequest.cs
@@ -22,6 +22,7 @@ namespace Listenarr.Api.Models
     {
         public string Url { get; set; } = string.Empty;
         public int? Port { get; set; }
-        public string ApiKey { get; set; } = string.Empty;
+        public string? ApiKey { get; set; }
+        public string? TagFilter { get; set; }
     }
 }

--- a/listenarr.api/Models/ProwlarrImportRequest.cs
+++ b/listenarr.api/Models/ProwlarrImportRequest.cs
@@ -22,6 +22,7 @@ namespace Listenarr.Api.Models
     {
         public string Url { get; set; } = string.Empty;
         public int? Port { get; set; }
+        public bool ClearPort { get; set; }
         public string? ApiKey { get; set; }
         public string? TagFilter { get; set; }
     }

--- a/listenarr.api/Services/Adapters/QbittorrentAdapter.cs
+++ b/listenarr.api/Services/Adapters/QbittorrentAdapter.cs
@@ -1128,6 +1128,12 @@ namespace Listenarr.Api.Services.Adapters
             // On API >= 2.6.1, ContentPath/OutputPath is already set correctly from content_path field
             if (!string.IsNullOrEmpty(result.ContentPath))
             {
+                var localPath = await _pathMappingService.TranslatePathAsync(client.Id, result.ContentPath);
+                if (!string.IsNullOrWhiteSpace(localPath))
+                {
+                    result.ContentPath = localPath;
+                }
+
                 _logger.LogDebug("Using existing ContentPath for import: {Path}", result.ContentPath);
                 return result;
             }

--- a/listenarr.api/Services/ApiResponseRedactor.cs
+++ b/listenarr.api/Services/ApiResponseRedactor.cs
@@ -55,6 +55,11 @@ public static class ApiResponseRedactor
             clone.DiscordBotToken = RedactedValue;
         }
 
+        if (!string.IsNullOrWhiteSpace(clone.ProwlarrApiKeyEncrypted))
+        {
+            clone.ProwlarrApiKeyEncrypted = RedactedValue;
+        }
+
         if (clone.Webhooks != null)
         {
             foreach (var webhook in clone.Webhooks.Where(w => !string.IsNullOrWhiteSpace(w.Url)))

--- a/listenarr.api/Services/AudioFileService.cs
+++ b/listenarr.api/Services/AudioFileService.cs
@@ -326,7 +326,7 @@ namespace Listenarr.Api.Services
 
             try
             {
-                return Path.GetFullPath(path)
+                return FileUtils.NormalizeStoredPath(path)
                     .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
             }
             catch

--- a/listenarr.api/Services/ConfigurationService.cs
+++ b/listenarr.api/Services/ConfigurationService.cs
@@ -19,6 +19,7 @@
 using System.Text.Json;
 using Listenarr.Domain.Models;
 using Listenarr.Infrastructure.Models;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 
 namespace Listenarr.Api.Services
@@ -29,13 +30,22 @@ namespace Listenarr.Api.Services
         private readonly ILogger<ConfigurationService> _logger;
         private readonly IUserService _userService;
         private readonly IStartupConfigService _startupConfigService;
+        private readonly IDataProtector _prowlarrImportProtector;
 
-        public ConfigurationService(ListenArrDbContext dbContext, ILogger<ConfigurationService> logger, IUserService userService, IStartupConfigService startupConfigService)
+        public ConfigurationService(
+            ListenArrDbContext dbContext,
+            ILogger<ConfigurationService> logger,
+            IUserService userService,
+            IStartupConfigService startupConfigService,
+            IDataProtectionProvider? dataProtectionProvider = null)
         {
             _dbContext = dbContext;
             _logger = logger;
             _userService = userService;
             _startupConfigService = startupConfigService;
+            _prowlarrImportProtector =
+                (dataProtectionProvider ?? new EphemeralDataProtectionProvider())
+                    .CreateProtector("Listenarr.ConfigurationService.ProwlarrImport");
         }
 
         // API Configuration methods
@@ -430,6 +440,94 @@ namespace Listenarr.Api.Services
                 // Re-throw to let higher-level handlers surface the failure. We intentionally
                 // do not attempt to alter the schema automatically here.
                 throw;
+            }
+        }
+
+        public async Task<ProwlarrImportConnectionSettings> GetProwlarrImportSettingsAsync(bool includeSecret = false)
+        {
+            try
+            {
+                var settings = await _dbContext.ApplicationSettings
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(s => s.Id == 1);
+
+                if (settings == null)
+                {
+                    return new ProwlarrImportConnectionSettings();
+                }
+
+                var result = new ProwlarrImportConnectionSettings
+                {
+                    Url = settings.ProwlarrUrl?.Trim() ?? string.Empty,
+                    Port = settings.ProwlarrPort,
+                    TagFilter = settings.ProwlarrTagFilter?.Trim(),
+                    HasSavedApiKey = !string.IsNullOrWhiteSpace(settings.ProwlarrApiKeyEncrypted),
+                };
+
+                if (includeSecret && result.HasSavedApiKey)
+                {
+                    result.ApiKey = TryUnprotectProwlarrApiKey(settings.ProwlarrApiKeyEncrypted);
+                    if (string.IsNullOrWhiteSpace(result.ApiKey))
+                    {
+                        result.HasSavedApiKey = false;
+                    }
+                }
+
+                return result;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogError(ex, "Error loading saved Prowlarr import settings");
+                return new ProwlarrImportConnectionSettings();
+            }
+        }
+
+        public async Task<ProwlarrImportConnectionSettings> SaveProwlarrImportSettingsAsync(ProwlarrImportConnectionSettings settings)
+        {
+            try
+            {
+                var existing = await _dbContext.ApplicationSettings.FirstOrDefaultAsync(s => s.Id == 1);
+                if (existing == null)
+                {
+                    existing = new ApplicationSettings { Id = 1 };
+                    _dbContext.ApplicationSettings.Add(existing);
+                }
+
+                existing.ProwlarrUrl = string.IsNullOrWhiteSpace(settings.Url) ? string.Empty : settings.Url.Trim();
+                existing.ProwlarrPort = settings.Port;
+                existing.ProwlarrTagFilter = string.IsNullOrWhiteSpace(settings.TagFilter) ? null : settings.TagFilter.Trim();
+
+                if (!string.IsNullOrWhiteSpace(settings.ApiKey)
+                    && !string.Equals(settings.ApiKey, ApiResponseRedactor.RedactedValue, StringComparison.Ordinal))
+                {
+                    existing.ProwlarrApiKeyEncrypted = _prowlarrImportProtector.Protect(settings.ApiKey.Trim());
+                }
+
+                await _dbContext.SaveChangesAsync();
+                return await GetProwlarrImportSettingsAsync();
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogError(ex, "Error saving Prowlarr import settings");
+                throw;
+            }
+        }
+
+        private string? TryUnprotectProwlarrApiKey(string? encryptedApiKey)
+        {
+            if (string.IsNullOrWhiteSpace(encryptedApiKey))
+            {
+                return null;
+            }
+
+            try
+            {
+                return _prowlarrImportProtector.Unprotect(encryptedApiKey);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogWarning(ex, "Failed to decrypt saved Prowlarr import API key");
+                return null;
             }
         }
 

--- a/listenarr.api/Services/ConfigurationService.cs
+++ b/listenarr.api/Services/ConfigurationService.cs
@@ -323,12 +323,39 @@ namespace Listenarr.Api.Services
                         Triggers = w.Triggers?.ToList() ?? new List<string>(),
                         IsEnabled = w.IsEnabled
                     }).ToList();
+                    var priorProwlarrUrl = existing.ProwlarrUrl;
+                    var priorProwlarrPort = existing.ProwlarrPort;
+                    var priorProwlarrApiKeyEncrypted = existing.ProwlarrApiKeyEncrypted;
+                    var priorProwlarrTagFilter = existing.ProwlarrTagFilter;
 
                     // Update existing settings (this may set complex properties to null if omitted in the payload)
                     _dbContext.Entry(existing).CurrentValues.SetValues(settings);
                     // Manually update list property
                     existing.AllowedFileExtensions = settings.AllowedFileExtensions;
                     existing.ImportBlacklistExtensions = settings.ImportBlacklistExtensions ?? new List<string>();
+
+                    // Preserve saved Prowlarr import settings when unrelated settings payloads omit them.
+                    // The dedicated Prowlarr import flow manages these values separately.
+                    if (settings.ProwlarrUrl == null)
+                    {
+                        existing.ProwlarrUrl = priorProwlarrUrl;
+                    }
+
+                    if (settings.ProwlarrPort == null)
+                    {
+                        existing.ProwlarrPort = priorProwlarrPort;
+                    }
+
+                    if (settings.ProwlarrTagFilter == null)
+                    {
+                        existing.ProwlarrTagFilter = priorProwlarrTagFilter;
+                    }
+
+                    if (string.IsNullOrWhiteSpace(settings.ProwlarrApiKeyEncrypted)
+                        || string.Equals(settings.ProwlarrApiKeyEncrypted, ApiResponseRedactor.RedactedValue, StringComparison.Ordinal))
+                    {
+                        existing.ProwlarrApiKeyEncrypted = priorProwlarrApiKeyEncrypted;
+                    }
 
                     // Explicitly update collection/complex properties so EF's current values
                     // replacement doesn't inadvertently skip or null them (ensures conversions

--- a/listenarr.api/Services/FileUtils.cs
+++ b/listenarr.api/Services/FileUtils.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.RegularExpressions;
 using Listenarr.Domain.Models;
 
@@ -78,6 +80,46 @@ namespace Listenarr.Api.Services
             }
 
             return normalized;
+        }
+
+        public static string NormalizeStoredPath(string? path, Func<string, string?>? longPathResolver = null)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return string.Empty;
+            }
+
+            var trimmedPath = path.Trim();
+            string normalizedPath;
+            try
+            {
+                normalizedPath = Path.GetFullPath(trimmedPath);
+            }
+            catch (Exception caughtEx_0) when (caughtEx_0 is not OperationCanceledException && caughtEx_0 is not OutOfMemoryException && caughtEx_0 is not StackOverflowException)
+            {
+                normalizedPath = trimmedPath;
+            }
+
+            if (string.IsNullOrWhiteSpace(normalizedPath))
+            {
+                return trimmedPath;
+            }
+
+            var resolver = longPathResolver;
+            if (resolver == null && !OperatingSystem.IsWindows())
+            {
+                return normalizedPath;
+            }
+
+            resolver ??= TryResolveLongWindowsPath;
+            try
+            {
+                return ExpandKnownWindowsPathSegments(normalizedPath, resolver);
+            }
+            catch (Exception caughtEx_00) when (caughtEx_00 is not OperationCanceledException && caughtEx_00 is not OutOfMemoryException && caughtEx_00 is not StackOverflowException)
+            {
+                return normalizedPath;
+            }
         }
 
         public static bool IsBlacklistedImportFile(string filePath, IEnumerable<string>? blacklistExtensions)
@@ -314,8 +356,8 @@ namespace Listenarr.Api.Services
                 if (string.IsNullOrWhiteSpace(childPath) || string.IsNullOrWhiteSpace(rootPath))
                     return false;
 
-                var normalizedChild = Path.GetFullPath(childPath);
-                var normalizedRoot = Path.GetFullPath(rootPath)
+                var normalizedChild = NormalizeStoredPath(childPath);
+                var normalizedRoot = NormalizeStoredPath(rootPath)
                     .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
                     + Path.DirectorySeparatorChar;
 
@@ -338,7 +380,7 @@ namespace Listenarr.Api.Services
                             return null;
                         }
 
-                        var fullPath = Path.GetFullPath(path);
+                        var fullPath = NormalizeStoredPath(path);
                         return Path.GetDirectoryName(fullPath) ?? fullPath;
                     })
                     .Where(path => !string.IsNullOrWhiteSpace(path))
@@ -397,8 +439,8 @@ namespace Listenarr.Api.Services
 
         private static string GetCommonPath(string firstPath, string secondPath)
         {
-            var normalizedFirst = Path.GetFullPath(firstPath);
-            var normalizedSecond = Path.GetFullPath(secondPath);
+            var normalizedFirst = NormalizeStoredPath(firstPath);
+            var normalizedSecond = NormalizeStoredPath(secondPath);
             var minLength = Math.Min(normalizedFirst.Length, normalizedSecond.Length);
             var commonLength = 0;
 
@@ -482,5 +524,80 @@ namespace Listenarr.Api.Services
 
             return string.Empty;
         }
+
+        private static string ExpandKnownWindowsPathSegments(string path, Func<string, string?> longPathResolver)
+        {
+            var pathRoot = Path.GetPathRoot(path);
+            if (string.IsNullOrWhiteSpace(pathRoot))
+            {
+                return path;
+            }
+
+            var remainingPath = path[pathRoot.Length..];
+            if (string.IsNullOrEmpty(remainingPath))
+            {
+                return path;
+            }
+
+            var hasTrailingSeparator = path.EndsWith(Path.DirectorySeparatorChar)
+                || path.EndsWith(Path.AltDirectorySeparatorChar);
+
+            var segments = remainingPath
+                .Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries);
+
+            var currentPath = pathRoot;
+            var forceResolve = longPathResolver != TryResolveLongWindowsPath;
+
+            foreach (var segment in segments)
+            {
+                var candidatePath = Path.Combine(currentPath, segment);
+                var canResolve = forceResolve || Directory.Exists(candidatePath) || File.Exists(candidatePath);
+                if (!canResolve)
+                {
+                    currentPath = candidatePath;
+                    continue;
+                }
+
+                var resolvedPath = longPathResolver(candidatePath);
+                currentPath = string.IsNullOrWhiteSpace(resolvedPath) ? candidatePath : resolvedPath!;
+            }
+
+            if (hasTrailingSeparator && !currentPath.EndsWith(Path.DirectorySeparatorChar) && !currentPath.EndsWith(Path.AltDirectorySeparatorChar))
+            {
+                currentPath += Path.DirectorySeparatorChar;
+            }
+
+            return currentPath;
+        }
+
+        private static string? TryResolveLongWindowsPath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return null;
+            }
+
+            var buffer = new StringBuilder(Math.Max(260, path.Length + 16));
+            var result = GetLongPathName(path, buffer, buffer.Capacity);
+            if (result == 0)
+            {
+                return null;
+            }
+
+            if (result > buffer.Capacity)
+            {
+                buffer = new StringBuilder((int)result);
+                result = GetLongPathName(path, buffer, buffer.Capacity);
+                if (result == 0)
+                {
+                    return null;
+                }
+            }
+
+            return buffer.ToString();
+        }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern uint GetLongPathName(string shortPath, StringBuilder longPathBuffer, int bufferLength);
     }
 }

--- a/listenarr.api/Services/FileUtils.cs
+++ b/listenarr.api/Services/FileUtils.cs
@@ -550,9 +550,7 @@ namespace Listenarr.Api.Services
 
             foreach (var segment in segments)
             {
-                var normalizedSegment = Path.IsPathRooted(segment)
-                    ? segment.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-                    : segment;
+                var normalizedSegment = NormalizeRelativePathSegment(segment);
                 var candidatePath = Path.Combine(currentPath, normalizedSegment);
                 var canResolve = forceResolve || Directory.Exists(candidatePath) || File.Exists(candidatePath);
                 if (!canResolve)
@@ -571,6 +569,28 @@ namespace Listenarr.Api.Services
             }
 
             return currentPath;
+        }
+
+        private static string NormalizeRelativePathSegment(string segment)
+        {
+            if (string.IsNullOrEmpty(segment))
+            {
+                return string.Empty;
+            }
+
+            var normalizedSegment = segment.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (!Path.IsPathRooted(normalizedSegment))
+            {
+                return normalizedSegment;
+            }
+
+            var root = Path.GetPathRoot(normalizedSegment);
+            if (!string.IsNullOrEmpty(root) && normalizedSegment.Length >= root.Length)
+            {
+                normalizedSegment = normalizedSegment[root.Length..];
+            }
+
+            return normalizedSegment.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         }
 
         private static string? TryResolveLongWindowsPath(string path)

--- a/listenarr.api/Services/FileUtils.cs
+++ b/listenarr.api/Services/FileUtils.cs
@@ -550,7 +550,10 @@ namespace Listenarr.Api.Services
 
             foreach (var segment in segments)
             {
-                var candidatePath = Path.Combine(currentPath, segment);
+                var normalizedSegment = Path.IsPathRooted(segment)
+                    ? segment.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                    : segment;
+                var candidatePath = Path.Combine(currentPath, normalizedSegment);
                 var canResolve = forceResolve || Directory.Exists(candidatePath) || File.Exists(candidatePath);
                 if (!canResolve)
                 {
@@ -575,6 +578,11 @@ namespace Listenarr.Api.Services
             if (string.IsNullOrWhiteSpace(path))
             {
                 return null;
+            }
+
+            if (!OperatingSystem.IsWindows())
+            {
+                return path;
             }
 
             var buffer = new StringBuilder(Math.Max(260, path.Length + 16));

--- a/listenarr.api/Services/IServices.cs
+++ b/listenarr.api/Services/IServices.cs
@@ -361,6 +361,18 @@ namespace Listenarr.Api.Services
         Task SaveApplicationSettingsAsync(ApplicationSettings settings);
 
         /// <summary>
+        /// Gets the saved Prowlarr import connection settings.
+        /// </summary>
+        /// <param name="includeSecret">When true, includes the decrypted API key for server-side use.</param>
+        Task<ProwlarrImportConnectionSettings> GetProwlarrImportSettingsAsync(bool includeSecret = false);
+
+        /// <summary>
+        /// Saves the Prowlarr import connection settings.
+        /// </summary>
+        /// <param name="settings">The connection settings to save.</param>
+        Task<ProwlarrImportConnectionSettings> SaveProwlarrImportSettingsAsync(ProwlarrImportConnectionSettings settings);
+
+        /// <summary>
         /// Gets the startup configuration
         /// </summary>
         /// <returns>Startup configuration</returns>

--- a/listenarr.api/Services/ImportService.cs
+++ b/listenarr.api/Services/ImportService.cs
@@ -201,7 +201,7 @@ namespace Listenarr.Api.Services
                         var ab = await db.Audiobooks.FindAsync(new object[] { audiobookId.Value }, ct);
                         if (ab != null && !string.IsNullOrWhiteSpace(ab.BasePath))
                         {
-                            basePathForFile = ab.BasePath; // custom/base path
+                            basePathForFile = FileUtils.NormalizeStoredPath(ab.BasePath); // custom/base path
                             usingAudiobookBasePath = true;
                             _logger.LogDebug("ImportSingleFile: using audiobook base path for download {DownloadId}: {BasePath}", downloadId, basePathForFile);
                             // For audiobook base path, default to filename-only unless the user explicitly configures a file pattern
@@ -573,7 +573,7 @@ namespace Listenarr.Api.Services
                             {
                                 await using var db = await _dbFactory.CreateDbContextAsync(ct);
                                 abForNaming = await db.Audiobooks.FindAsync(new object[] { audiobookId.Value }, ct);
-                                if (abForNaming != null && !string.IsNullOrWhiteSpace(abForNaming.BasePath)) destDirForFile = abForNaming.BasePath;
+                                if (abForNaming != null && !string.IsNullOrWhiteSpace(abForNaming.BasePath)) destDirForFile = FileUtils.NormalizeStoredPath(abForNaming.BasePath);
                             }
                             catch (Exception caughtEx_6) when (caughtEx_6 is not OperationCanceledException && caughtEx_6 is not OutOfMemoryException && caughtEx_6 is not StackOverflowException) { destDirForFile = string.Empty; }
                         }
@@ -883,6 +883,7 @@ namespace Listenarr.Api.Services
             try
             {
                 var normalizedCandidate = Path.GetFullPath(candidateBasePath);
+                normalizedCandidate = FileUtils.NormalizeStoredPath(normalizedCandidate);
 
                 await using var db = await _dbFactory.CreateDbContextAsync(ct);
                 var audiobook = await db.Audiobooks.FindAsync(new object[] { audiobookId }, ct);
@@ -893,10 +894,17 @@ namespace Listenarr.Api.Services
 
                 if (!string.IsNullOrWhiteSpace(audiobook.BasePath))
                 {
-                    var normalizedExisting = Path.GetFullPath(audiobook.BasePath);
-                    if (string.Equals(normalizedExisting, normalizedCandidate, StringComparison.OrdinalIgnoreCase)
-                        || FileUtils.IsPathWithinRoot(normalizedCandidate, normalizedExisting))
+                    var normalizedExisting = FileUtils.NormalizeStoredPath(audiobook.BasePath);
+                    var matchesExisting = string.Equals(normalizedExisting, normalizedCandidate, StringComparison.OrdinalIgnoreCase);
+                    var candidateWithinExisting = FileUtils.IsPathWithinRoot(normalizedCandidate, normalizedExisting);
+                    if (matchesExisting || candidateWithinExisting)
                     {
+                        if (!string.Equals(audiobook.BasePath, normalizedExisting, StringComparison.Ordinal))
+                        {
+                            audiobook.BasePath = normalizedExisting;
+                            await db.SaveChangesAsync(ct);
+                        }
+
                         return;
                     }
                 }

--- a/listenarr.api/Services/LibraryAddService.cs
+++ b/listenarr.api/Services/LibraryAddService.cs
@@ -133,7 +133,7 @@ namespace Listenarr.Api.Services
                 Explicit = metadata.Explicit,
                 Abridged = metadata.Abridged,
                 Monitored = request.Monitored,
-                BasePath = string.IsNullOrWhiteSpace(request.DestinationPath) ? null : request.DestinationPath
+                BasePath = string.IsNullOrWhiteSpace(request.DestinationPath) ? null : FileUtils.NormalizeStoredPath(request.DestinationPath)
             };
 
             SyncImportedIdentifiersFromLegacyFields(audiobook);

--- a/listenarr.api/Services/ScanBackgroundService.cs
+++ b/listenarr.api/Services/ScanBackgroundService.cs
@@ -559,7 +559,11 @@ namespace Listenarr.Api.Services
                 return string.Empty;
 
             // Convert all paths to directory paths (get parent directory for each file)
-            var directories = filePaths.Select(p => Path.GetDirectoryName(p) ?? p).Distinct().ToList();
+            var directories = filePaths
+                .Select(p => FileUtils.NormalizeStoredPath(Path.GetDirectoryName(p) ?? p))
+                .Where(p => !string.IsNullOrWhiteSpace(p))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
             if (directories.Count == 1)
             {
@@ -606,11 +610,12 @@ namespace Listenarr.Api.Services
             if (!paths.Any())
                 return string.Empty;
 
-            var firstPath = paths[0];
+            var firstPath = FileUtils.NormalizeStoredPath(paths[0]);
             var commonPath = firstPath;
 
-            foreach (var path in paths.Skip(1))
+            foreach (var rawPath in paths.Skip(1))
             {
+                var path = FileUtils.NormalizeStoredPath(rawPath);
                 var minLength = Math.Min(commonPath.Length, path.Length);
                 var commonLength = 0;
 

--- a/listenarr.domain/Models/Configuration.cs
+++ b/listenarr.domain/Models/Configuration.cs
@@ -212,6 +212,27 @@ namespace Listenarr.Domain.Models
         public string? DiscordBotToken { get; set; }
 
         /// <summary>
+        /// Saved Prowlarr host/URL used by the indexer import flow.
+        /// </summary>
+        public string? ProwlarrUrl { get; set; }
+
+        /// <summary>
+        /// Optional saved Prowlarr port used by the indexer import flow.
+        /// </summary>
+        public int? ProwlarrPort { get; set; }
+
+        /// <summary>
+        /// Encrypted Prowlarr API key used by the indexer import flow.
+        /// </summary>
+        public string? ProwlarrApiKeyEncrypted { get; set; }
+
+        /// <summary>
+        /// Optional Prowlarr tag filter used by the indexer import flow.
+        /// When set, only indexers with this tag are imported and the audiobook category filter is bypassed.
+        /// </summary>
+        public string? ProwlarrTagFilter { get; set; }
+
+        /// <summary>
         /// Primary command group name (e.g. "request"). We'll create a slash command with this group and
         /// a subcommand for specific request types (e.g. "audiobook").
         /// </summary>

--- a/listenarr.domain/Models/ProwlarrImportConnectionSettings.cs
+++ b/listenarr.domain/Models/ProwlarrImportConnectionSettings.cs
@@ -1,0 +1,11 @@
+namespace Listenarr.Domain.Models
+{
+    public class ProwlarrImportConnectionSettings
+    {
+        public string Url { get; set; } = string.Empty;
+        public int? Port { get; set; }
+        public string? ApiKey { get; set; }
+        public string? TagFilter { get; set; }
+        public bool HasSavedApiKey { get; set; }
+    }
+}

--- a/listenarr.infrastructure/Migrations/20260321023426_AddProwlarrImportSettingsToApplicationSettings.Designer.cs
+++ b/listenarr.infrastructure/Migrations/20260321023426_AddProwlarrImportSettingsToApplicationSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Listenarr.Infrastructure.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Listenarr.Infrastructure.Migrations
 {
     [DbContext(typeof(ListenArrDbContext))]
-    partial class ListenArrDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260321023426_AddProwlarrImportSettingsToApplicationSettings")]
+    partial class AddProwlarrImportSettingsToApplicationSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.13");
@@ -192,9 +195,6 @@ namespace Listenarr.Infrastructure.Migrations
 
                     b.Property<int?>("ProwlarrPort")
                         .HasColumnType("INTEGER");
-
-                    b.Property<string>("ProwlarrTagFilter")
-                        .HasColumnType("TEXT");
 
                     b.Property<string>("ProwlarrUrl")
                         .HasColumnType("TEXT");

--- a/listenarr.infrastructure/Migrations/20260321023426_AddProwlarrImportSettingsToApplicationSettings.cs
+++ b/listenarr.infrastructure/Migrations/20260321023426_AddProwlarrImportSettingsToApplicationSettings.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Listenarr.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProwlarrImportSettingsToApplicationSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ProwlarrApiKeyEncrypted",
+                table: "ApplicationSettings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ProwlarrPort",
+                table: "ApplicationSettings",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ProwlarrUrl",
+                table: "ApplicationSettings",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProwlarrApiKeyEncrypted",
+                table: "ApplicationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "ProwlarrPort",
+                table: "ApplicationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "ProwlarrUrl",
+                table: "ApplicationSettings");
+        }
+    }
+}

--- a/listenarr.infrastructure/Migrations/20260321025509_AddProwlarrTagFilterToApplicationSettings.Designer.cs
+++ b/listenarr.infrastructure/Migrations/20260321025509_AddProwlarrTagFilterToApplicationSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Listenarr.Infrastructure.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Listenarr.Infrastructure.Migrations
 {
     [DbContext(typeof(ListenArrDbContext))]
-    partial class ListenArrDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260321025509_AddProwlarrTagFilterToApplicationSettings")]
+    partial class AddProwlarrTagFilterToApplicationSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.13");

--- a/listenarr.infrastructure/Migrations/20260321025509_AddProwlarrTagFilterToApplicationSettings.cs
+++ b/listenarr.infrastructure/Migrations/20260321025509_AddProwlarrTagFilterToApplicationSettings.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Listenarr.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProwlarrTagFilterToApplicationSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ProwlarrTagFilter",
+                table: "ApplicationSettings",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProwlarrTagFilter",
+                table: "ApplicationSettings");
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "listenarr",
-  "version": "0.2.58",
+  "version": "0.2.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "listenarr",
-      "version": "0.2.58",
+      "version": "0.2.59",
       "dependencies": {
         "concurrently": "^9.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "listenarr",
-  "version": "0.2.58",
+  "version": "0.2.59",
   "private": true,
   "description": "Listenarr - Automated audiobook downloading and management",
   "scripts": {

--- a/tests/Listenarr.Api.Tests/ConfigurationControllerSettingsTests.cs
+++ b/tests/Listenarr.Api.Tests/ConfigurationControllerSettingsTests.cs
@@ -1,0 +1,51 @@
+using Listenarr.Api.Controllers;
+using Listenarr.Api.Hubs;
+using Listenarr.Api.Services;
+using Listenarr.Domain.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Listenarr.Api.Tests
+{
+    public class ConfigurationControllerSettingsTests
+    {
+        [Fact]
+        public async Task GetApplicationSettings_DoesNotReturnEncryptedProwlarrApiKey()
+        {
+            var configurationService = new Mock<IConfigurationService>(MockBehavior.Strict);
+            configurationService
+                .Setup(x => x.GetApplicationSettingsAsync())
+                .ReturnsAsync(new ApplicationSettings
+                {
+                    Id = 1,
+                    ProwlarrUrl = "http://localhost",
+                    ProwlarrPort = 9696,
+                    ProwlarrApiKeyEncrypted = "ciphertext",
+                    ProwlarrTagFilter = "audiobooks"
+                });
+
+            var controller = new ConfigurationController(
+                configurationService.Object,
+                NullLogger<ConfigurationController>.Instance,
+                Mock.Of<IUserService>(),
+                Mock.Of<IHubContext<SettingsHub>>(),
+                Mock.Of<IDownloadService>(),
+                null!);
+
+            var result = await controller.GetApplicationSettings();
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            var settings = Assert.IsType<ApplicationSettings>(ok.Value);
+
+            Assert.Equal("http://localhost", settings.ProwlarrUrl);
+            Assert.Equal(9696, settings.ProwlarrPort);
+            Assert.Equal("audiobooks", settings.ProwlarrTagFilter);
+            Assert.Null(settings.ProwlarrApiKeyEncrypted);
+
+            configurationService.Verify(x => x.GetApplicationSettingsAsync(), Times.Once);
+            configurationService.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/tests/Listenarr.Api.Tests/ConfigurationServiceTests.cs
+++ b/tests/Listenarr.Api.Tests/ConfigurationServiceTests.cs
@@ -153,5 +153,48 @@ namespace Listenarr.Api.Tests
             Assert.Equal("audiobooks", serverView.TagFilter);
         }
 
+        [Fact]
+        public async Task SaveApplicationSettings_PreservesSavedProwlarrImportSettings_WhenPayloadOmitsThem()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddDbContext<ListenArrDbContext>(opts => opts.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+
+            var provider = services.BuildServiceProvider(validateScopes: true);
+
+            using var scope = provider.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ListenArrDbContext>();
+            var logger = scope.ServiceProvider.GetRequiredService<ILogger<ConfigurationService>>();
+
+            var svc = new ConfigurationService(
+                db,
+                logger,
+                new Mock<IUserService>().Object,
+                new Mock<IStartupConfigService>().Object);
+
+            await svc.SaveProwlarrImportSettingsAsync(new ProwlarrImportConnectionSettings
+            {
+                Url = "http://localhost",
+                Port = 9696,
+                ApiKey = "saved-secret",
+                TagFilter = "audiobooks"
+            });
+
+            await svc.SaveApplicationSettingsAsync(new ApplicationSettings
+            {
+                Id = 1,
+                OutputPath = "C:\\updated-output"
+            });
+
+            var savedConnection = await svc.GetProwlarrImportSettingsAsync(includeSecret: true);
+            Assert.Equal("http://localhost", savedConnection.Url);
+            Assert.Equal(9696, savedConnection.Port);
+            Assert.Equal("saved-secret", savedConnection.ApiKey);
+            Assert.Equal("audiobooks", savedConnection.TagFilter);
+
+            var stored = await db.ApplicationSettings.AsNoTracking().FirstAsync(s => s.Id == 1);
+            Assert.False(string.IsNullOrWhiteSpace(stored.ProwlarrApiKeyEncrypted));
+        }
+
     }
 }

--- a/tests/Listenarr.Api.Tests/ConfigurationServiceTests.cs
+++ b/tests/Listenarr.Api.Tests/ConfigurationServiceTests.cs
@@ -109,5 +109,49 @@ namespace Listenarr.Api.Tests
             Assert.Equal("DirectWebhook", reloaded.Webhooks![0].Name);
         }
 
+        [Fact]
+        public async Task ProwlarrImportSettings_ApiKey_IsEncryptedAtRest_AndRecoveredForServerUse()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddDbContext<ListenArrDbContext>(opts => opts.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+
+            var provider = services.BuildServiceProvider(validateScopes: true);
+
+            using var scope = provider.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ListenArrDbContext>();
+            var logger = scope.ServiceProvider.GetRequiredService<ILogger<ConfigurationService>>();
+
+            var mockUser = new Mock<IUserService>();
+            var mockStartup = new Mock<IStartupConfigService>();
+
+            var svc = new ConfigurationService(db, logger, mockUser.Object, mockStartup.Object);
+
+            await svc.SaveProwlarrImportSettingsAsync(new ProwlarrImportConnectionSettings
+            {
+                Url = "http://localhost",
+                Port = 9696,
+                ApiKey = "super-secret-prowlarr-key",
+                TagFilter = "audiobooks",
+            });
+
+            var stored = await db.ApplicationSettings.AsNoTracking().FirstAsync(s => s.Id == 1);
+            Assert.Equal("http://localhost", stored.ProwlarrUrl);
+            Assert.Equal(9696, stored.ProwlarrPort);
+            Assert.Equal("audiobooks", stored.ProwlarrTagFilter);
+            Assert.False(string.IsNullOrWhiteSpace(stored.ProwlarrApiKeyEncrypted));
+            Assert.NotEqual("super-secret-prowlarr-key", stored.ProwlarrApiKeyEncrypted);
+
+            var frontendView = await svc.GetProwlarrImportSettingsAsync(includeSecret: false);
+            Assert.True(frontendView.HasSavedApiKey);
+            Assert.Null(frontendView.ApiKey);
+            Assert.Equal("audiobooks", frontendView.TagFilter);
+
+            var serverView = await svc.GetProwlarrImportSettingsAsync(includeSecret: true);
+            Assert.True(serverView.HasSavedApiKey);
+            Assert.Equal("super-secret-prowlarr-key", serverView.ApiKey);
+            Assert.Equal("audiobooks", serverView.TagFilter);
+        }
+
     }
 }

--- a/tests/Listenarr.Api.Tests/FileUtilsTests.cs
+++ b/tests/Listenarr.Api.Tests/FileUtilsTests.cs
@@ -209,5 +209,58 @@ namespace Listenarr.Api.Tests
 
             try { Directory.Delete(dir, true); } catch { }
         }
+
+        [Fact]
+        public void NormalizeStoredPath_ExpandsResolvedShortSegments_WhenResolverProvided()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            string ResolveLongPath(string candidatePath)
+            {
+                return candidatePath switch
+                {
+                    @"C:\Books\ALD2A5~9" => @"C:\Books\A Long Directory Name",
+                    @"C:\Books\A Long Directory Name\FILES~1" => @"C:\Books\A Long Directory Name\Files",
+                    _ => candidatePath
+                };
+            }
+
+            var normalized = FileUtils.NormalizeStoredPath(
+                @"C:\Books\ALD2A5~9\FILES~1\Track 01.mp3",
+                ResolveLongPath);
+
+            Assert.Equal(
+                @"C:\Books\A Long Directory Name\Files\Track 01.mp3",
+                normalized);
+        }
+
+        [Fact]
+        public void NormalizeStoredPath_PreservesUnresolvedTail_WhenResolverProvided()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            string ResolveLongPath(string candidatePath)
+            {
+                return candidatePath switch
+                {
+                    @"C:\Library\AUDIOB~1" => @"C:\Library\Audiobook Imports",
+                    _ => candidatePath
+                };
+            }
+
+            var normalized = FileUtils.NormalizeStoredPath(
+                @"C:\Library\AUDIOB~1\New Folder\Disc 1",
+                ResolveLongPath);
+
+            Assert.Equal(
+                @"C:\Library\Audiobook Imports\New Folder\Disc 1",
+                normalized);
+        }
     }
 }

--- a/tests/Listenarr.Api.Tests/FileUtilsTests.cs
+++ b/tests/Listenarr.Api.Tests/FileUtilsTests.cs
@@ -262,5 +262,22 @@ namespace Listenarr.Api.Tests
                 @"C:\Library\Audiobook Imports\New Folder\Disc 1",
                 normalized);
         }
+
+        [Fact]
+        public void NormalizeStoredPath_DoesNotDropPrefix_WhenMalformedDriveSegmentAppears()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            var normalized = FileUtils.NormalizeStoredPath(
+                @"C:\Books\D:\Files\Track 01.mp3",
+                candidatePath => candidatePath);
+
+            Assert.Equal(
+                @"C:\Books\Files\Track 01.mp3",
+                normalized);
+        }
     }
 }

--- a/tests/Listenarr.Api.Tests/ImportServiceTests.cs
+++ b/tests/Listenarr.Api.Tests/ImportServiceTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -399,6 +401,92 @@ namespace Listenarr.Api.Tests
             TryDeleteDirectory(outputRoot, recursive: true);
         }
 
+        [Fact]
+        public async Task ImportSingleFile_WithWindowsShortBasePath_NormalizesFinalPath()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            var outputRoot = Path.Join(Path.GetTempPath(), $"import-out-{Guid.NewGuid()}");
+            var longBasePath = Path.Join(outputRoot, "A Very Long Audiobook Folder Name");
+            Directory.CreateDirectory(longBasePath);
+
+            var shortBasePath = TryGetShortPathName(longBasePath);
+            if (string.IsNullOrWhiteSpace(shortBasePath)
+                || string.Equals(shortBasePath, longBasePath, StringComparison.OrdinalIgnoreCase)
+                || !shortBasePath.Contains('~'))
+            {
+                TryDeleteDirectory(outputRoot, recursive: true);
+                return;
+            }
+
+            var sourceDir = Path.Join(Path.GetTempPath(), $"import-src-{Guid.NewGuid()}");
+            Directory.CreateDirectory(sourceDir);
+            var sourceFile = Path.Join(sourceDir, "source-track.m4b");
+            await File.WriteAllTextAsync(sourceFile, "dummy");
+
+            var settings = new ApplicationSettings
+            {
+                OutputPath = outputRoot,
+                CompletedFileAction = "Move",
+                EnableMetadataProcessing = false,
+                FileNamingPattern = "{Title}"
+            };
+
+            var options = new DbContextOptionsBuilder<ListenArrDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            await using (var seed = new ListenArrDbContext(options))
+            {
+                seed.Audiobooks.Add(new Audiobook
+                {
+                    Id = 321,
+                    Title = "A Great Book",
+                    Authors = new System.Collections.Generic.List<string> { "Test Author" },
+                    BasePath = shortBasePath
+                });
+                await seed.SaveChangesAsync();
+            }
+
+            var dbFactoryMock = new Mock<IDbContextFactory<ListenArrDbContext>>();
+            dbFactoryMock
+                .Setup(f => f.CreateDbContextAsync(It.IsAny<System.Threading.CancellationToken>()))
+                .ReturnsAsync(() => new ListenArrDbContext(options));
+
+            using var provider = TestServiceFactory.BuildServiceProvider(services =>
+            {
+                services.AddSingleton<IDbContextFactory<ListenArrDbContext>>(dbFactoryMock.Object);
+                services.AddSingleton<IFileNamingService>(new FileNamingService(new TestConfigurationService(), new NullLogger<FileNamingService>()));
+                services.AddSingleton<IMetadataService>(new Mock<IMetadataService>().Object);
+                services.AddSingleton<IImportService>(sp => new ImportService(
+                    dbFactoryMock.Object,
+                    sp.GetRequiredService<IServiceScopeFactory>(),
+                    sp.GetRequiredService<IFileNamingService>(),
+                    sp.GetService<IMetadataService>(),
+                    new NullLogger<ImportService>()));
+            });
+
+            var importService = provider.GetRequiredService<IImportService>();
+
+            var result = await importService.ImportSingleFileAsync("dl-short-path", 321, sourceFile, settings);
+
+            Assert.True(result.Success);
+            Assert.NotNull(result.FinalPath);
+            Assert.StartsWith(longBasePath.TrimEnd(Path.DirectorySeparatorChar), result.FinalPath!, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("~", result.FinalPath!, StringComparison.Ordinal);
+
+            await using var verify = new ListenArrDbContext(options);
+            var stored = await verify.Audiobooks.FindAsync(321);
+            Assert.NotNull(stored);
+            Assert.Equal(longBasePath, stored!.BasePath);
+
+            TryDeleteDirectory(sourceDir, recursive: true);
+            TryDeleteDirectory(outputRoot, recursive: true);
+        }
+
         private static void TryDeleteDirectory(string path, bool recursive = false)
         {
             try
@@ -414,5 +502,30 @@ namespace Listenarr.Api.Tests
                 Console.Error.WriteLine($"Ignoring cleanup failure for '{path}': {ex.Message}");
             }
         }
+
+        private static string? TryGetShortPathName(string longPath)
+        {
+            var buffer = new StringBuilder(260);
+            var result = GetShortPathName(longPath, buffer, buffer.Capacity);
+            if (result == 0)
+            {
+                return null;
+            }
+
+            if (result > buffer.Capacity)
+            {
+                buffer = new StringBuilder((int)result);
+                result = GetShortPathName(longPath, buffer, buffer.Capacity);
+                if (result == 0)
+                {
+                    return null;
+                }
+            }
+
+            return buffer.ToString();
+        }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern uint GetShortPathName(string longPath, StringBuilder shortPathBuffer, int bufferLength);
     }
 }

--- a/tests/Listenarr.Api.Tests/ImportServiceTests.cs
+++ b/tests/Listenarr.Api.Tests/ImportServiceTests.cs
@@ -505,6 +505,11 @@ namespace Listenarr.Api.Tests
 
         private static string? TryGetShortPathName(string longPath)
         {
+            if (!OperatingSystem.IsWindows() || string.IsNullOrWhiteSpace(longPath))
+            {
+                return null;
+            }
+
             var buffer = new StringBuilder(260);
             var result = GetShortPathName(longPath, buffer, buffer.Capacity);
             if (result == 0)

--- a/tests/Listenarr.Api.Tests/IndexersAuthTests.cs
+++ b/tests/Listenarr.Api.Tests/IndexersAuthTests.cs
@@ -41,7 +41,7 @@ namespace Listenarr.Api.Tests
             var logger = NullLogger<Listenarr.Api.Controllers.IndexersController>.Instance;
             var client = new HttpClient(handler);
 
-            return new Listenarr.Api.Controllers.IndexersController(db, logger, client);
+            return new Listenarr.Api.Controllers.IndexersController(db, logger, client, new TestConfigurationService());
         }
 
         [Fact]

--- a/tests/Listenarr.Api.Tests/IndexersControllerProwlarrImportTests.cs
+++ b/tests/Listenarr.Api.Tests/IndexersControllerProwlarrImportTests.cs
@@ -156,6 +156,35 @@ namespace Listenarr.Api.Tests
         }
 
         [Fact]
+        public async Task ImportFromProwlarr_WhenRequestClearsSavedPort_DoesNotReuseStoredPort()
+        {
+            using var harness = new ControllerHarness(new CaptureHandler());
+
+            await harness.ConfigurationService.SaveProwlarrImportSettingsAsync(new ProwlarrImportConnectionSettings
+            {
+                Url = "http://localhost",
+                Port = 9696,
+                ApiKey = "saved-test-key"
+            });
+
+            var result = await harness.Controller.ImportFromProwlarr(new ProwlarrImportRequest
+            {
+                Url = "http://localhost:7878",
+                ClearPort = true,
+                ApiKey = string.Empty
+            });
+
+            Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(harness.Handler.LastRequest);
+            Assert.Equal("http://localhost:7878/api/v1/indexer", harness.Handler.LastRequest!.RequestUri!.ToString());
+
+            var saved = await harness.ConfigurationService.GetProwlarrImportSettingsAsync(includeSecret: true);
+            Assert.Equal("http://localhost:7878", saved.Url);
+            Assert.Null(saved.Port);
+            Assert.Equal("saved-test-key", saved.ApiKey);
+        }
+
+        [Fact]
         public async Task ImportFromProwlarr_WhenTagFilterIsSet_ImportsMatchingTaggedIndexers_WithoutAudiobookCategories()
         {
             var indexerPayload = """
@@ -270,6 +299,100 @@ namespace Listenarr.Api.Tests
             Assert.Equal("Saved Tag Indexer (Prowlarr)", imported.Name);
             Assert.Equal("saved-tag-key", imported.ApiKey);
             Assert.Equal(string.Empty, imported.Categories);
+        }
+
+        [Fact]
+        public async Task ImportFromProwlarr_WhenTagFilterNeedsTagMap_AndLookupFails_ReturnsBadGateway()
+        {
+            var indexerPayload = """
+                [
+                  {
+                    "id": 15,
+                    "name": "Numeric Tag Indexer",
+                    "protocol": "torrent",
+                    "tags": [7],
+                    "categories": [5000],
+                    "enable": true
+                  }
+                ]
+                """;
+
+            using var harness = new ControllerHarness(new CaptureHandler(request =>
+            {
+                var path = request.RequestUri?.AbsolutePath ?? string.Empty;
+                if (path.EndsWith("/api/v1/tag", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.Forbidden)
+                    {
+                        Content = new StringContent("Forbidden", Encoding.UTF8, "text/plain")
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(indexerPayload, Encoding.UTF8, "application/json")
+                };
+            }));
+
+            var result = await harness.Controller.ImportFromProwlarr(new ProwlarrImportRequest
+            {
+                Url = "http://localhost",
+                Port = 9696,
+                ApiKey = "tag-key",
+                TagFilter = "audiobooks"
+            });
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal((int)HttpStatusCode.BadGateway, objectResult.StatusCode);
+            Assert.Empty(await harness.Db.Indexers.AsNoTracking().ToListAsync());
+        }
+
+        [Fact]
+        public async Task ImportFromProwlarr_WhenTagNamesArePresent_AndLookupFails_StillImportsMatchingIndexer()
+        {
+            var indexerPayload = """
+                [
+                  {
+                    "id": 16,
+                    "name": "Named Tag Indexer",
+                    "protocol": "torrent",
+                    "tagNames": ["audiobooks"],
+                    "categories": [5000],
+                    "enable": true
+                  }
+                ]
+                """;
+
+            using var harness = new ControllerHarness(new CaptureHandler(request =>
+            {
+                var path = request.RequestUri?.AbsolutePath ?? string.Empty;
+                if (path.EndsWith("/api/v1/tag", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.Forbidden)
+                    {
+                        Content = new StringContent("Forbidden", Encoding.UTF8, "text/plain")
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(indexerPayload, Encoding.UTF8, "application/json")
+                };
+            }));
+
+            var result = await harness.Controller.ImportFromProwlarr(new ProwlarrImportRequest
+            {
+                Url = "http://localhost",
+                Port = 9696,
+                ApiKey = "tag-key",
+                TagFilter = "audiobooks"
+            });
+
+            Assert.IsType<OkObjectResult>(result);
+
+            var imported = await harness.Db.Indexers.AsNoTracking().SingleAsync();
+            Assert.Equal("Named Tag Indexer (Prowlarr)", imported.Name);
+            Assert.Equal("Torznab", imported.Implementation);
         }
 
         [Fact]

--- a/tests/Listenarr.Api.Tests/IndexersControllerProwlarrImportTests.cs
+++ b/tests/Listenarr.Api.Tests/IndexersControllerProwlarrImportTests.cs
@@ -4,10 +4,12 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Listenarr.Api.Models;
+using Listenarr.Api.Services;
 using Listenarr.Domain.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Moq;
 using Xunit;
 
 namespace Listenarr.Api.Tests
@@ -16,27 +18,22 @@ namespace Listenarr.Api.Tests
     {
         private sealed class CaptureHandler : HttpMessageHandler
         {
-            private readonly HttpResponseMessage _response = new(HttpStatusCode.OK)
-            {
-                Content = new StringContent("[]", Encoding.UTF8, "application/json")
-            };
+            private readonly Func<HttpRequestMessage, HttpResponseMessage> _responseFactory;
 
             public HttpRequestMessage? LastRequest { get; private set; }
+
+            public CaptureHandler(Func<HttpRequestMessage, HttpResponseMessage>? responseFactory = null)
+            {
+                _responseFactory = responseFactory ?? (_ => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]", Encoding.UTF8, "application/json")
+                });
+            }
 
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 LastRequest = request;
-                return Task.FromResult(_response);
-            }
-
-            protected override void Dispose(bool disposing)
-            {
-                if (disposing)
-                {
-                    _response.Dispose();
-                }
-
-                base.Dispose(disposing);
+                return Task.FromResult(_responseFactory(request));
             }
         }
 
@@ -45,6 +42,7 @@ namespace Listenarr.Api.Tests
             private readonly LoggerFactory _loggerFactory;
             private readonly ListenArrDbContext _db;
             private readonly HttpClient _client;
+            private readonly ConfigurationService _configurationService;
 
             public ControllerHarness(CaptureHandler handler)
             {
@@ -56,13 +54,21 @@ namespace Listenarr.Api.Tests
                 _db = new ListenArrDbContext(options);
                 _loggerFactory = new LoggerFactory();
                 _client = new HttpClient(handler);
+                _configurationService = new ConfigurationService(
+                    _db,
+                    _loggerFactory.CreateLogger<ConfigurationService>(),
+                    new Mock<IUserService>().Object,
+                    new Mock<IStartupConfigService>().Object);
                 Controller = new Listenarr.Api.Controllers.IndexersController(
                     _db,
                     _loggerFactory.CreateLogger<Listenarr.Api.Controllers.IndexersController>(),
-                    _client);
+                    _client,
+                    _configurationService);
             }
 
             public CaptureHandler Handler { get; }
+            public ListenArrDbContext Db => _db;
+            public ConfigurationService ConfigurationService => _configurationService;
             public Listenarr.Api.Controllers.IndexersController Controller { get; }
 
             public void Dispose()
@@ -122,6 +128,213 @@ namespace Listenarr.Api.Tests
             Assert.IsType<OkObjectResult>(result);
             Assert.NotNull(harness.Handler.LastRequest);
             Assert.Equal("https://192.168.1.10:4545/api/v1/indexer", harness.Handler.LastRequest!.RequestUri!.ToString());
+        }
+
+        [Fact]
+        public async Task ImportFromProwlarr_UsesSavedApiKey_WhenRequestOmitsApiKey()
+        {
+            using var harness = new ControllerHarness(new CaptureHandler());
+
+            await harness.ConfigurationService.SaveProwlarrImportSettingsAsync(new ProwlarrImportConnectionSettings
+            {
+                Url = "192.168.1.10",
+                Port = 4545,
+                ApiKey = "saved-test-key"
+            });
+
+            var result = await harness.Controller.ImportFromProwlarr(new ProwlarrImportRequest
+            {
+                Url = "192.168.1.10",
+                Port = 4545,
+                ApiKey = string.Empty
+            });
+
+            Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(harness.Handler.LastRequest);
+            Assert.True(harness.Handler.LastRequest!.Headers.TryGetValues("X-Api-Key", out var apiKeyValues));
+            Assert.Contains("saved-test-key", apiKeyValues!);
+        }
+
+        [Fact]
+        public async Task ImportFromProwlarr_WhenTagFilterIsSet_ImportsMatchingTaggedIndexers_WithoutAudiobookCategories()
+        {
+            var indexerPayload = """
+                [
+                  {
+                    "id": 12,
+                    "name": "Tagged Indexer",
+                    "protocol": "torrent",
+                    "tags": [7],
+                    "categories": [5000],
+                    "enable": true
+                  }
+                ]
+                """;
+            var tagPayload = """
+                [
+                  { "id": 7, "label": "audiobooks" }
+                ]
+                """;
+
+            using var harness = new ControllerHarness(new CaptureHandler(request =>
+            {
+                var path = request.RequestUri?.AbsolutePath ?? string.Empty;
+                if (path.EndsWith("/api/v1/tag", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(tagPayload, Encoding.UTF8, "application/json")
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(indexerPayload, Encoding.UTF8, "application/json")
+                };
+            }));
+
+            var result = await harness.Controller.ImportFromProwlarr(new ProwlarrImportRequest
+            {
+                Url = "http://localhost",
+                Port = 9696,
+                ApiKey = "tag-key",
+                TagFilter = "audiobooks"
+            });
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(ok.Value);
+
+            var imported = await harness.Db.Indexers.AsNoTracking().SingleAsync();
+            Assert.Equal("Tagged Indexer (Prowlarr)", imported.Name);
+            Assert.Equal("Torznab", imported.Implementation);
+            Assert.Equal("tag-key", imported.ApiKey);
+            Assert.Equal(string.Empty, imported.Categories);
+        }
+
+        [Fact]
+        public async Task ImportFromProwlarr_WhenSavedTagFilterExists_UsesItWhenRequestOmitsTagFilter()
+        {
+            var indexerPayload = """
+                [
+                  {
+                    "id": 13,
+                    "name": "Saved Tag Indexer",
+                    "protocol": "torrent",
+                    "tags": [7],
+                    "categories": [5000],
+                    "enable": true
+                  }
+                ]
+                """;
+            var tagPayload = """
+                [
+                  { "id": 7, "label": "audiobooks" }
+                ]
+                """;
+
+            using var harness = new ControllerHarness(new CaptureHandler(request =>
+            {
+                var path = request.RequestUri?.AbsolutePath ?? string.Empty;
+                if (path.EndsWith("/api/v1/tag", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(tagPayload, Encoding.UTF8, "application/json")
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(indexerPayload, Encoding.UTF8, "application/json")
+                };
+            }));
+
+            await harness.ConfigurationService.SaveProwlarrImportSettingsAsync(new ProwlarrImportConnectionSettings
+            {
+                Url = "http://localhost",
+                Port = 9696,
+                ApiKey = "saved-tag-key",
+                TagFilter = "audiobooks"
+            });
+
+            var result = await harness.Controller.ImportFromProwlarr(new ProwlarrImportRequest
+            {
+                Url = "http://localhost",
+                Port = 9696,
+                ApiKey = string.Empty
+            });
+
+            Assert.IsType<OkObjectResult>(result);
+
+            var imported = await harness.Db.Indexers.AsNoTracking().SingleAsync();
+            Assert.Equal("Saved Tag Indexer (Prowlarr)", imported.Name);
+            Assert.Equal("saved-tag-key", imported.ApiKey);
+            Assert.Equal(string.Empty, imported.Categories);
+        }
+
+        [Fact]
+        public async Task ImportFromProwlarr_WhenRequestClearsSavedTagFilter_FallsBackToAudiobookCategories()
+        {
+            var indexerPayload = """
+                [
+                  {
+                    "id": 14,
+                    "name": "Category Indexer",
+                    "protocol": "usenet",
+                    "tags": [7],
+                    "categories": [3030],
+                    "enable": true
+                  }
+                ]
+                """;
+            var tagPayload = """
+                [
+                  { "id": 7, "label": "audiobooks" }
+                ]
+                """;
+
+            using var harness = new ControllerHarness(new CaptureHandler(request =>
+            {
+                var path = request.RequestUri?.AbsolutePath ?? string.Empty;
+                if (path.EndsWith("/api/v1/tag", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(tagPayload, Encoding.UTF8, "application/json")
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(indexerPayload, Encoding.UTF8, "application/json")
+                };
+            }));
+
+            await harness.ConfigurationService.SaveProwlarrImportSettingsAsync(new ProwlarrImportConnectionSettings
+            {
+                Url = "http://localhost",
+                Port = 9696,
+                ApiKey = "saved-tag-key",
+                TagFilter = "audiobooks"
+            });
+
+            var result = await harness.Controller.ImportFromProwlarr(new ProwlarrImportRequest
+            {
+                Url = "http://localhost",
+                Port = 9696,
+                ApiKey = string.Empty,
+                TagFilter = string.Empty
+            });
+
+            Assert.IsType<OkObjectResult>(result);
+
+            var imported = await harness.Db.Indexers.AsNoTracking().SingleAsync();
+            Assert.Equal("Category Indexer (Prowlarr)", imported.Name);
+            Assert.Equal("Newznab", imported.Implementation);
+            Assert.Equal("3030", imported.Categories);
+
+            var saved = await harness.ConfigurationService.GetProwlarrImportSettingsAsync();
+            Assert.Null(saved.TagFilter);
         }
     }
 }

--- a/tests/Listenarr.Api.Tests/IndexersControllerProwlarrImportTests.cs
+++ b/tests/Listenarr.Api.Tests/IndexersControllerProwlarrImportTests.cs
@@ -336,5 +336,51 @@ namespace Listenarr.Api.Tests
             var saved = await harness.ConfigurationService.GetProwlarrImportSettingsAsync();
             Assert.Null(saved.TagFilter);
         }
+
+        [Fact]
+        public async Task ImportFromProwlarr_WhenReplacementCredentialsFail_PreservesSavedConnectionSettings()
+        {
+            using var harness = new ControllerHarness(new CaptureHandler(request =>
+            {
+                if (request.Headers.TryGetValues("X-Api-Key", out var values)
+                    && values.Contains("bad-key"))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                    {
+                        Content = new StringContent("Unauthorized", Encoding.UTF8, "text/plain")
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]", Encoding.UTF8, "application/json")
+                };
+            }));
+
+            await harness.ConfigurationService.SaveProwlarrImportSettingsAsync(new ProwlarrImportConnectionSettings
+            {
+                Url = "http://localhost",
+                Port = 9696,
+                ApiKey = "good-key",
+                TagFilter = "audiobooks"
+            });
+
+            var result = await harness.Controller.ImportFromProwlarr(new ProwlarrImportRequest
+            {
+                Url = "http://localhost",
+                Port = 9696,
+                ApiKey = "bad-key",
+                TagFilter = "other-tag"
+            });
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal((int)HttpStatusCode.Unauthorized, objectResult.StatusCode);
+
+            var saved = await harness.ConfigurationService.GetProwlarrImportSettingsAsync(includeSecret: true);
+            Assert.Equal("http://localhost", saved.Url);
+            Assert.Equal(9696, saved.Port);
+            Assert.Equal("good-key", saved.ApiKey);
+            Assert.Equal("audiobooks", saved.TagFilter);
+        }
     }
 }

--- a/tests/Listenarr.Api.Tests/IndexersControllerTests.cs
+++ b/tests/Listenarr.Api.Tests/IndexersControllerTests.cs
@@ -48,7 +48,7 @@ namespace Listenarr.Api.Tests
             var handler = new CaptureHandler(resp);
             var client = new HttpClient(handler);
 
-            var controller = new Listenarr.Api.Controllers.IndexersController(db, logger, client);
+            var controller = new Listenarr.Api.Controllers.IndexersController(db, logger, client, new TestConfigurationService());
 
             var indexer = new Indexer
             {

--- a/tests/Listenarr.Api.Tests/IndexersNewznabAuthTests.cs
+++ b/tests/Listenarr.Api.Tests/IndexersNewznabAuthTests.cs
@@ -42,7 +42,7 @@ namespace Listenarr.Api.Tests
             var logger = new LoggerFactory().CreateLogger<Listenarr.Api.Controllers.IndexersController>();
             var client = new HttpClient(handler);
 
-            return new Listenarr.Api.Controllers.IndexersController(db, logger, client);
+            return new Listenarr.Api.Controllers.IndexersController(db, logger, client, new TestConfigurationService());
         }
 
         [Fact]
@@ -384,7 +384,7 @@ namespace Listenarr.Api.Tests
 
             var logger = new LoggerFactory().CreateLogger<Listenarr.Api.Controllers.IndexersController>();
             var client = new HttpClient(handler);
-            var controller = new Listenarr.Api.Controllers.IndexersController(db, logger, client);
+            var controller = new Listenarr.Api.Controllers.IndexersController(db, logger, client, new TestConfigurationService());
 
             // Act - Test persisted indexer
             var result = await controller.Test(indexer.Id);
@@ -434,7 +434,7 @@ namespace Listenarr.Api.Tests
 
             var logger = new LoggerFactory().CreateLogger<Listenarr.Api.Controllers.IndexersController>();
             var client = new HttpClient(handler);
-            var controller = new Listenarr.Api.Controllers.IndexersController(db, logger, client);
+            var controller = new Listenarr.Api.Controllers.IndexersController(db, logger, client, new TestConfigurationService());
 
             // Act
             var result = await controller.Test(indexer.Id);

--- a/tests/Listenarr.Api.Tests/IndexersPersistedAuthTests.cs
+++ b/tests/Listenarr.Api.Tests/IndexersPersistedAuthTests.cs
@@ -43,7 +43,7 @@ namespace Listenarr.Api.Tests
             var logger = new LoggerFactory().CreateLogger<Listenarr.Api.Controllers.IndexersController>();
             var handler = new CaptureHandler(httpResponse);
             var client = new HttpClient(handler);
-            var controller = new Listenarr.Api.Controllers.IndexersController(db, logger, client);
+            var controller = new Listenarr.Api.Controllers.IndexersController(db, logger, client, new TestConfigurationService());
 
             return (db, controller, handler);
         }

--- a/tests/Listenarr.Api.Tests/QbittorrentAdapterTests.cs
+++ b/tests/Listenarr.Api.Tests/QbittorrentAdapterTests.cs
@@ -289,6 +289,93 @@ namespace Listenarr.Api.Tests
             await Task.CompletedTask;
         }
 
+        [Fact]
+        [Trait("Area", "QbittorrentImportPathResolution")]
+        [Trait("Scenario", "DockerAutoImportAppliesRemotePathMapping")]
+        public async Task GetImportItemAsync_PrepopulatedContentPath_AppliesRemoteMapping_ForDockerAutoImport()
+        {
+            var pathMapMock = new Mock<Listenarr.Api.Services.IRemotePathMappingService>(MockBehavior.Strict);
+            pathMapMock
+                .Setup(m => m.TranslatePathAsync("qbit-client", "/qbit-downloads/Stephen King/It.m4b"))
+                .ReturnsAsync("D:/media/downloads/Stephen King/It.m4b");
+
+            using var http = new HttpClient(new DelegatingHandlerMock((_, _) =>
+                throw new InvalidOperationException("HTTP should not be called when qBittorrent content_path is already available.")));
+
+            var adapter = new QbittorrentAdapter(
+                new TestHttpClientFactory(http),
+                pathMapMock.Object,
+                Mock.Of<ITorrentFileDownloader>(),
+                NullLogger<QbittorrentAdapter>.Instance);
+
+            var client = new DownloadClientConfiguration
+            {
+                Id = "qbit-client",
+                Type = "qbittorrent",
+                Host = "localhost",
+                Port = 8080
+            };
+
+            var queueItem = new QueueItem
+            {
+                Id = "dl-qbit-docker",
+                Title = "It",
+                Status = "completed",
+                ContentPath = "/qbit-downloads/Stephen King/It.m4b",
+                DownloadClientId = client.Id
+            };
+
+            var resolved = await adapter.GetImportItemAsync(client, new Download { Id = queueItem.Id }, queueItem);
+
+            Assert.Equal("D:/media/downloads/Stephen King/It.m4b", NormalizePath(resolved.ContentPath));
+            pathMapMock.Verify(
+                m => m.TranslatePathAsync("qbit-client", "/qbit-downloads/Stephen King/It.m4b"),
+                Times.Once);
+        }
+
+        [Fact]
+        [Trait("Area", "QbittorrentImportPathResolution")]
+        [Trait("Scenario", "LocalAutoImportKeepsExistingPath")]
+        public async Task GetImportItemAsync_PrepopulatedContentPath_KeepsLocalPath_ForNonDockerAutoImport()
+        {
+            const string localPath = "D:\\media\\downloads\\Stephen King\\It.m4b";
+            var pathMapMock = new Mock<Listenarr.Api.Services.IRemotePathMappingService>(MockBehavior.Strict);
+            pathMapMock
+                .Setup(m => m.TranslatePathAsync("qbit-client", localPath))
+                .ReturnsAsync(localPath);
+
+            using var http = new HttpClient(new DelegatingHandlerMock((_, _) =>
+                throw new InvalidOperationException("HTTP should not be called when qBittorrent content_path is already available.")));
+
+            var adapter = new QbittorrentAdapter(
+                new TestHttpClientFactory(http),
+                pathMapMock.Object,
+                Mock.Of<ITorrentFileDownloader>(),
+                NullLogger<QbittorrentAdapter>.Instance);
+
+            var client = new DownloadClientConfiguration
+            {
+                Id = "qbit-client",
+                Type = "qbittorrent",
+                Host = "localhost",
+                Port = 8080
+            };
+
+            var queueItem = new QueueItem
+            {
+                Id = "dl-qbit-local",
+                Title = "It",
+                Status = "completed",
+                ContentPath = localPath,
+                DownloadClientId = client.Id
+            };
+
+            var resolved = await adapter.GetImportItemAsync(client, new Download { Id = queueItem.Id }, queueItem);
+
+            Assert.Equal("D:/media/downloads/Stephen King/It.m4b", NormalizePath(resolved.ContentPath));
+            pathMapMock.Verify(m => m.TranslatePathAsync("qbit-client", localPath), Times.Once);
+        }
+
         private static List<Dictionary<string, JsonElement>> ParseFiles(string json)
         {
             var root = JsonDocument.Parse(json).RootElement;

--- a/tests/Listenarr.Api.Tests/TestServiceFactory.cs
+++ b/tests/Listenarr.Api.Tests/TestServiceFactory.cs
@@ -216,6 +216,12 @@ internal class TestConfigurationService : Listenarr.Api.Services.IConfigurationS
     public Task SaveApplicationSettingsAsync(Listenarr.Domain.Models.ApplicationSettings settings)
         => Task.CompletedTask;
 
+    public Task<Listenarr.Domain.Models.ProwlarrImportConnectionSettings> GetProwlarrImportSettingsAsync(bool includeSecret = false)
+        => Task.FromResult(new Listenarr.Domain.Models.ProwlarrImportConnectionSettings());
+
+    public Task<Listenarr.Domain.Models.ProwlarrImportConnectionSettings> SaveProwlarrImportSettingsAsync(Listenarr.Domain.Models.ProwlarrImportConnectionSettings settings)
+        => Task.FromResult(settings);
+
     public Task<Listenarr.Domain.Models.StartupConfig> GetStartupConfigAsync()
         => Task.FromResult(new Listenarr.Domain.Models.StartupConfig());
 


### PR DESCRIPTION
## Summary
This release focuses on making day-to-day setup and importing smoother for self-hosted users. Prowlarr imports are now easier to reuse and control, completed download importing is more reliable in Docker setups, and a few frustrating edge cases around authenticated log downloads and Windows path handling have been cleaned up.

## Added
- Added saved Prowlarr import connection settings so the URL, port, and securely stored API key can be reused instead of being re-entered every time.
- Added an optional Prowlarr tag filter so users can import only indexers with a specific tag.
- Added regression coverage around Prowlarr import persistence, tag-based import filtering, authenticated log downloads, and qBittorrent auto-import path handling.

## Changed
- Changed Prowlarr import behavior so a configured tag filter overrides the default audiobook category import rules.
- Changed the Prowlarr import modal to preload saved values, allow clearing a saved tag override, and close automatically after a successful import.
- Changed the Wanted manual search table so the download action stays visible while horizontally scrolling wider result sets. Closes #410 

## Fixed
- Fixed Prowlarr import settings being lost across refreshes by persisting them in the database, with the API key stored securely at rest. Closes #396.
- Fixed `System > Recent Logs > Download Logs` so downloads work correctly when authentication is enabled. Closes #409.
- Fixed intermittent Windows short-path issues that could cause imported or stored library paths to show unexpected abbreviated folder names. Closes #420.
- Fixed qBittorrent completed-download auto import when remote path mappings are required, especially in Docker-style setups where qBittorrent and Listenarr use different filesystem paths. (Reported on Discord)
- Fixed the generic settings response so the encrypted saved Prowlarr API key is not exposed back to the frontend.
