### PR TITLE
Bump version to 0.2.60

### DIFF
--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>0.2.59</Version>
-    <AssemblyVersion>0.2.59</AssemblyVersion>
+    <Version>0.2.60</Version>
+    <AssemblyVersion>0.2.60</AssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);bin\**;bin/**;artifacts\**;artifacts/**</DefaultItemExcludes>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>


### PR DESCRIPTION
This PR bumps the application version to 0.2.60.
The change was produced automatically by the CI canary workflow.