### PR TITLE
Improve filename sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.61] - 2026-03-21
+
+### Added
+- **Portable path-sanitization regression coverage:** Added focused backend tests covering SMB/Windows-safe naming normalization for forbidden characters, reserved device names, trailing dot/space handling, and nested torrent-style import paths to guard against repeated `Series/Title` folder segments.
+
+### Changed
+- **Cross-platform library path sanitization:** Updated generated audiobook folder/file naming to normalize Windows/SMB-hostile characters even when Listenarr is running on Linux or Docker, replacing path-breaking separators like `:`, `/`, and `\` with readable portable output.
+
+### Fixed
+- **Windows/SMB folder-name mangling from Docker imports:** Fixed generated library paths so titles containing Windows-forbidden characters no longer create SMB-hostile folder names that can appear as mangled aliases from Windows clients.
+- **Portable filename edge cases:** Fixed generated folder/file names to trim trailing periods/spaces, remove control characters, and avoid reserved Windows device names like `CON`, `NUL`, `COM1`, and `LPT1`.
+- **Nested torrent import path validation:** Added regression protection to ensure nested torrent-style source folders import into a single `Author/Series/Title` destination structure without duplicating the `Series/Title` segments in the final library path.
+
 ## [0.2.60] - 2026-03-20
 
 ### Added

--- a/listenarr.api/Services/FileNamingService.cs
+++ b/listenarr.api/Services/FileNamingService.cs
@@ -332,21 +332,31 @@ namespace Listenarr.Api.Services
                         return EmptySentinel;
                     }
 
+                    string renderedValue;
+
                     // Apply formatting if specified
                     if (!string.IsNullOrEmpty(format))
                     {
                         // For numeric values with format (e.g., {DiskNumber:00})
                         if (value is int intValue)
                         {
-                            return intValue.ToString(format);
+                            renderedValue = intValue.ToString(format);
                         }
                         else if (int.TryParse(value.ToString(), out var parsedInt))
                         {
-                            return parsedInt.ToString(format);
+                            renderedValue = parsedInt.ToString(format);
+                        }
+                        else
+                        {
+                            renderedValue = value.ToString() ?? string.Empty;
                         }
                     }
+                    else
+                    {
+                        renderedValue = value.ToString() ?? string.Empty;
+                    }
 
-                    return value.ToString() ?? string.Empty;
+                    return SanitizePathComponent(renderedValue);
                 }
 
                 // Variable not found, return sentinel so we can optionally remove surrounding chars
@@ -454,9 +464,13 @@ namespace Listenarr.Api.Services
                 return "Unknown";
             }
 
-            if (ReservedWindowsDeviceNames.Contains(result))
+            var extensionSeparator = result.IndexOf('.');
+            var deviceNameStem = extensionSeparator >= 0 ? result[..extensionSeparator] : result;
+            if (ReservedWindowsDeviceNames.Contains(deviceNameStem))
             {
-                result += "_";
+                result = extensionSeparator >= 0
+                    ? deviceNameStem + "_" + result[extensionSeparator..]
+                    : result + "_";
             }
 
             return result;

--- a/listenarr.api/Services/FileNamingService.cs
+++ b/listenarr.api/Services/FileNamingService.cs
@@ -7,6 +7,14 @@ namespace Listenarr.Api.Services
 {
     public class FileNamingService : IFileNamingService
     {
+        private static readonly HashSet<char> PortableInvalidFileNameChars = BuildPortableInvalidFileNameChars();
+        private static readonly HashSet<string> ReservedWindowsDeviceNames = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "CON", "PRN", "AUX", "NUL",
+            "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+            "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+        };
+
         private readonly IConfigurationService _configService;
         private readonly ILogger<FileNamingService> _logger;
 
@@ -410,14 +418,19 @@ namespace Listenarr.Api.Services
                 return "Unknown";
             }
 
-            // Get invalid filename characters
-            var invalidChars = Path.GetInvalidFileNameChars();
-
-            // Replace invalid characters with underscore
             var sanitized = new StringBuilder();
             foreach (var c in pathComponent)
             {
-                if (invalidChars.Contains(c))
+                if (char.IsControl(c))
+                {
+                    continue;
+                }
+
+                if (c == ':' || c == '/' || c == '\\')
+                {
+                    sanitized.Append(" - ");
+                }
+                else if (PortableInvalidFileNameChars.Contains(c))
                 {
                     sanitized.Append('_');
                 }
@@ -427,16 +440,43 @@ namespace Listenarr.Api.Services
                 }
             }
 
-            // Trim and handle edge cases
-            var result = sanitized.ToString().Trim();
+            var result = sanitized.ToString();
+            result = Regex.Replace(result, @"\s+", " ");
+            result = Regex.Replace(result, @"(?:\s*-\s*){2,}", " - ");
+            result = Regex.Replace(result, @"_+", "_");
+            result = result.Trim();
+            result = result.TrimEnd('.', ' ');
+            result = Regex.Replace(result, @"^\s*[-_]+\s*", string.Empty);
+            result = Regex.Replace(result, @"\s*[-_]+\s*$", string.Empty);
 
-            // Ensure it's not empty after sanitization
             if (string.IsNullOrWhiteSpace(result))
             {
                 return "Unknown";
             }
 
+            if (ReservedWindowsDeviceNames.Contains(result))
+            {
+                result += "_";
+            }
+
             return result;
+        }
+
+        private static HashSet<char> BuildPortableInvalidFileNameChars()
+        {
+            var invalidChars = new HashSet<char>(Path.GetInvalidFileNameChars());
+
+            foreach (var c in "<>:\"/\\|?*")
+            {
+                invalidChars.Add(c);
+            }
+
+            for (int i = 0; i < 32; i++)
+            {
+                invalidChars.Add((char)i);
+            }
+
+            return invalidChars;
         }
 
         /// <summary>

--- a/tests/Listenarr.Api.Tests/FileNamingService_PatternSelectionTests.cs
+++ b/tests/Listenarr.Api.Tests/FileNamingService_PatternSelectionTests.cs
@@ -275,5 +275,21 @@ namespace Listenarr.Api.Tests
             Assert.Equal("NUL_.m4b", fileName);
             Assert.DoesNotContain("NUL. ", result);
         }
+
+        [Fact]
+        public void ApplyNamingPattern_WithSlashInVariable_DoesNotCreateNestedFolders()
+        {
+            var variables = new System.Collections.Generic.Dictionary<string, object>
+            {
+                ["Author"] = "John Scalzi",
+                ["Series"] = "The Dispatcher",
+                ["Title"] = "Book 1/2"
+            };
+
+            var result = _service.ApplyNamingPattern("{Author}/{Series}/{Title}", variables, treatAsFilename: false);
+
+            Assert.Equal($"John Scalzi{Path.DirectorySeparatorChar}The Dispatcher{Path.DirectorySeparatorChar}Book 1 - 2", result);
+            Assert.DoesNotContain($"{Path.DirectorySeparatorChar}Book 1{Path.DirectorySeparatorChar}2", result);
+        }
     }
 }

--- a/tests/Listenarr.Api.Tests/FileNamingService_PatternSelectionTests.cs
+++ b/tests/Listenarr.Api.Tests/FileNamingService_PatternSelectionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using Xunit;
 using Moq;
@@ -219,6 +220,60 @@ namespace Listenarr.Api.Tests
             // Assert - should produce a valid path
             Assert.NotNull(result);
             Assert.NotEmpty(result);
+        }
+
+        [Fact]
+        public async Task GenerateFilePathAsync_NormalizesPortableInvalidCharacters()
+        {
+            var settings = new ApplicationSettings
+            {
+                OutputPath = "/audiobooks",
+                FolderNamingPattern = "{Author}/{Series}/{Title}",
+                FileNamingPattern = "{Title}",
+                MultiFileNamingPattern = "{Title}-{DiskNumber:00}"
+            };
+            _mockConfigService.Setup(c => c.GetApplicationSettingsAsync()).ReturnsAsync(settings);
+
+            var metadata = new AudioMetadata
+            {
+                Title = "Murder by Other Means: The Dispatcher/Book 2?",
+                Artist = "John Scalzi",
+                Series = "The Dispatcher"
+            };
+
+            var result = await _service.GenerateFilePathAsync(metadata, diskNumber: null, chapterNumber: null, ".m4b");
+
+            Assert.DoesNotContain(":", result);
+            Assert.DoesNotContain("?", result);
+            Assert.DoesNotContain($"{Path.DirectorySeparatorChar}Murder by Other Means - The Dispatcher - Book 2 - ", result);
+            Assert.Contains("Murder by Other Means - The Dispatcher - Book 2", result);
+            Assert.EndsWith(".m4b", result);
+        }
+
+        [Fact]
+        public async Task GenerateFilePathAsync_NormalizesReservedNamesAndTrailingDots()
+        {
+            var settings = new ApplicationSettings
+            {
+                OutputPath = "/audiobooks",
+                FolderNamingPattern = "{Author}",
+                FileNamingPattern = "{Title}",
+                MultiFileNamingPattern = "{Title}-{DiskNumber:00}"
+            };
+            _mockConfigService.Setup(c => c.GetApplicationSettingsAsync()).ReturnsAsync(settings);
+
+            var metadata = new AudioMetadata
+            {
+                Title = "NUL. ",
+                Artist = "CON"
+            };
+
+            var result = await _service.GenerateFilePathAsync(metadata, diskNumber: null, chapterNumber: null, ".m4b");
+            var fileName = Path.GetFileName(result);
+
+            Assert.Contains($"{Path.DirectorySeparatorChar}CON_{Path.DirectorySeparatorChar}", result);
+            Assert.Equal("NUL_.m4b", fileName);
+            Assert.DoesNotContain("NUL. ", result);
         }
     }
 }

--- a/tests/Listenarr.Api.Tests/ImportServiceTests.cs
+++ b/tests/Listenarr.Api.Tests/ImportServiceTests.cs
@@ -402,6 +402,78 @@ namespace Listenarr.Api.Tests
         }
 
         [Fact]
+        public async Task ImportFilesFromDirectory_NestedTorrentFolders_DoNotDuplicateSeriesAndTitleSegments()
+        {
+            var outputRoot = Path.Join(Path.GetTempPath(), $"import-out-{Guid.NewGuid()}");
+            var sourceRoot = Path.Join(Path.GetTempPath(), $"import-src-{Guid.NewGuid()}");
+            var title = "Murder by Other Means: The Dispatcher, Book 2";
+            var author = "John Scalzi";
+            var series = "The Dispatcher";
+            var sanitizedTitle = SanitizePathComponentForCurrentPlatform(title);
+
+            var nestedSourceDir = Path.Join(sourceRoot, series, sanitizedTitle);
+            Directory.CreateDirectory(nestedSourceDir);
+
+            var sourceFile = Path.Join(nestedSourceDir, $"{sanitizedTitle}.m4b");
+            await File.WriteAllTextAsync(sourceFile, "dummy");
+
+            var settings = new ApplicationSettings
+            {
+                OutputPath = outputRoot,
+                CompletedFileAction = "Copy",
+                EnableMetadataProcessing = false,
+                FolderNamingPattern = "{Author}/{Series}/{Title}",
+                FileNamingPattern = "{Title}",
+                MultiFileNamingPattern = "{Title}-{DiskNumber:00}"
+            };
+
+            var metadataMock = new Mock<IMetadataService>();
+            metadataMock.Setup(m => m.ExtractFileMetadataAsync(sourceFile))
+                .ReturnsAsync(new AudioMetadata
+                {
+                    Title = title,
+                    Artist = author,
+                    AlbumArtist = author,
+                    Series = series,
+                    Format = "m4b"
+                });
+
+            var dbFactoryMock = new Mock<IDbContextFactory<ListenArrDbContext>>();
+            using var provider = TestServiceFactory.BuildServiceProvider(_ => { });
+
+            var importService = new ImportService(
+                dbFactoryMock.Object,
+                provider.GetRequiredService<IServiceScopeFactory>(),
+                new FileNamingService(new TestConfigurationService(), new NullLogger<FileNamingService>()),
+                metadataMock.Object,
+                new NullLogger<ImportService>());
+
+            var results = await importService.ImportFilesFromDirectoryAsync(
+                "nested-torrent",
+                audiobookId: null,
+                new[] { sourceFile },
+                settings);
+
+            var success = Assert.Single(results, r => r.Success);
+            Assert.NotNull(success.FinalPath);
+
+            var actualFullPath = Path.GetFullPath(success.FinalPath!);
+            var actualRelativePath = Path.GetRelativePath(outputRoot, actualFullPath);
+            var actualDirectory = Path.GetDirectoryName(actualRelativePath);
+            var actualFileName = Path.GetFileName(actualRelativePath);
+
+            Assert.Equal(Path.Combine(author, series, sanitizedTitle), actualDirectory);
+            Assert.StartsWith(sanitizedTitle, actualFileName, StringComparison.OrdinalIgnoreCase);
+            Assert.EndsWith(".m4b", actualFileName, StringComparison.OrdinalIgnoreCase);
+
+            var duplicatedSegment = Path.Combine(series, sanitizedTitle, series, sanitizedTitle);
+            Assert.DoesNotContain(duplicatedSegment, actualFullPath, StringComparison.OrdinalIgnoreCase);
+
+            TryDeleteDirectory(sourceRoot, recursive: true);
+            TryDeleteDirectory(outputRoot, recursive: true);
+        }
+
+        [Fact]
         public async Task ImportSingleFile_WithWindowsShortBasePath_NormalizesFinalPath()
         {
             if (!OperatingSystem.IsWindows())
@@ -501,6 +573,51 @@ namespace Listenarr.Api.Tests
             {
                 Console.Error.WriteLine($"Ignoring cleanup failure for '{path}': {ex.Message}");
             }
+        }
+
+        private static string SanitizePathComponentForCurrentPlatform(string value)
+        {
+            var sanitized = new StringBuilder();
+
+            foreach (var c in value)
+            {
+                if (char.IsControl(c))
+                {
+                    continue;
+                }
+
+                if (c == ':' || c == '/' || c == '\\')
+                {
+                    sanitized.Append(" - ");
+                }
+                else if (Path.GetInvalidFileNameChars().Contains(c) || "<>:\"/\\|?*".Contains(c))
+                {
+                    sanitized.Append('_');
+                }
+                else
+                {
+                    sanitized.Append(c);
+                }
+            }
+
+            var result = sanitized.ToString();
+            result = System.Text.RegularExpressions.Regex.Replace(result, @"\s+", " ");
+            result = System.Text.RegularExpressions.Regex.Replace(result, @"(?:\s*-\s*){2,}", " - ");
+            result = System.Text.RegularExpressions.Regex.Replace(result, @"_+", "_");
+            result = result.Trim().TrimEnd('.', ' ');
+            result = System.Text.RegularExpressions.Regex.Replace(result, @"^\s*[-_]+\s*", string.Empty);
+            result = System.Text.RegularExpressions.Regex.Replace(result, @"\s*[-_]+\s*$", string.Empty);
+
+            if (string.Equals(result, "CON", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(result, "PRN", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(result, "AUX", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(result, "NUL", StringComparison.OrdinalIgnoreCase)
+                || System.Text.RegularExpressions.Regex.IsMatch(result, @"^(COM|LPT)[1-9]$", System.Text.RegularExpressions.RegexOptions.IgnoreCase))
+            {
+                result += "_";
+            }
+
+            return string.IsNullOrWhiteSpace(result) ? "Unknown" : result;
         }
 
         private static string? TryGetShortPathName(string longPath)

--- a/tests/Listenarr.Api.Tests/ImportServiceTests.cs
+++ b/tests/Listenarr.Api.Tests/ImportServiceTests.cs
@@ -406,7 +406,7 @@ namespace Listenarr.Api.Tests
         {
             var outputRoot = Path.Join(Path.GetTempPath(), $"import-out-{Guid.NewGuid()}");
             var sourceRoot = Path.Join(Path.GetTempPath(), $"import-src-{Guid.NewGuid()}");
-            var title = "Murder by Other Means: The Dispatcher, Book 2";
+            var title = "Murder by Other Means: The Dispatcher/Book 2";
             var author = "John Scalzi";
             var series = "The Dispatcher";
             var sanitizedTitle = SanitizePathComponentForCurrentPlatform(title);
@@ -461,12 +461,13 @@ namespace Listenarr.Api.Tests
             var actualRelativePath = Path.GetRelativePath(outputRoot, actualFullPath);
             var actualDirectory = Path.GetDirectoryName(actualRelativePath);
             var actualFileName = Path.GetFileName(actualRelativePath);
+            var pathSeparator = Path.DirectorySeparatorChar.ToString();
 
-            Assert.Equal(Path.Combine(author, series, sanitizedTitle), actualDirectory);
+            Assert.Equal(string.Join(pathSeparator, author, series, sanitizedTitle), actualDirectory);
             Assert.StartsWith(sanitizedTitle, actualFileName, StringComparison.OrdinalIgnoreCase);
             Assert.EndsWith(".m4b", actualFileName, StringComparison.OrdinalIgnoreCase);
 
-            var duplicatedSegment = Path.Combine(series, sanitizedTitle, series, sanitizedTitle);
+            var duplicatedSegment = string.Join(pathSeparator, series, sanitizedTitle, series, sanitizedTitle);
             Assert.DoesNotContain(duplicatedSegment, actualFullPath, StringComparison.OrdinalIgnoreCase);
 
             TryDeleteDirectory(sourceRoot, recursive: true);


### PR DESCRIPTION
## Summary
This release improves how Listenarr creates audiobook folders and file names so they behave more consistently across Docker, Linux, SMB shares, and Windows clients. It smooths over characters that can look fine on one system but turn into broken or mangled names on another, helping imported audiobooks stay readable and accessible no matter how the library is mounted or browsed.

## Added
- Added regression coverage for cross-platform audiobook path generation, including SMB/Windows-safe naming, reserved-name handling, trailing dot/space cleanup, and nested torrent-style import paths.
- Added import-path validation tests to guard against repeated `Series/Title` folder segments during completed download imports.

## Changed
- Changed library path generation to use portable filename sanitization instead of relying only on the current host OS rules.
- Changed generated audiobook folder and file names so problematic separators like `:`, `/`, and `\` are normalized into cleaner cross-platform-safe output.

## Fixed
- Fixed Docker/Linux-created audiobook paths showing up as mangled folder names from Windows or SMB clients when titles contained characters that are invalid on Windows.
- Fixed generated audiobook names to trim trailing periods and spaces that can break or behave inconsistently on Windows-based clients.
- Fixed generated names to avoid reserved Windows device names like `CON`, `NUL`, `COM1`, and `LPT1`.
- Fixed regression protection around nested torrent imports so Listenarr keeps importing into a single `Author/Series/Title` destination structure instead of allowing repeated `Series/Title` path segments.
