### PR TITLE
Bug Backlog

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Create Pull Request for version bump
         id: create_pr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GH_PAT }}
           commit-message: "[skip ci] Bump version to ${{ steps.resolve-version.outputs.VERSION }}"
@@ -108,14 +108,50 @@ jobs:
           body: |
             This PR bumps the application version to ${{ steps.resolve-version.outputs.VERSION }}.
             The change was produced automatically by the CI canary workflow.
-          labels: automated,version-bump
+
+      - name: Label version bump PR
+        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
+        continue-on-error: true
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GH_PAT }}
+          script: |
+            const pr = Number('${{ steps.create_pr.outputs.pull-request-number }}');
+            if (!pr) {
+              core.info('No PR number returned; skipping labels.');
+              return;
+            }
+
+            for (let attempt = 1; attempt <= 5; attempt++) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr,
+                  labels: ['automated', 'version-bump']
+                });
+                core.info(`Applied labels to PR #${pr} on attempt ${attempt}.`);
+                return;
+              } catch (error) {
+                if (attempt === 5) {
+                  core.warning(`Failed to label PR #${pr}: ${error.message}`);
+                  return;
+                }
+
+                const delayMs = attempt * 2000;
+                core.warning(`Label attempt ${attempt} failed for PR #${pr}: ${error.message}. Retrying in ${delayMs}ms.`);
+                await new Promise(resolve => setTimeout(resolve, delayMs));
+              }
+            }
 
       - name: Merge version bump PR (skip CI)
+        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
         uses: actions/github-script@v6
         env:
           PR_NUMBER: ${{ steps.create_pr.outputs['pull-request-number'] }}
           NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
         with:
+          github-token: ${{ secrets.GH_PAT }}
           script: |
             const pr = parseInt(process.env.PR_NUMBER, 10);
             if (!pr) throw new Error('PR number missing');

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Create Pull Request for version bump
         id: create_pr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GH_PAT }}
           commit-message: "[skip ci] Bump version to ${{ steps.resolve-version.outputs.VERSION }}"
@@ -108,14 +108,50 @@ jobs:
           body: |
             This PR bumps the application version to ${{ steps.resolve-version.outputs.VERSION }}.
             The change was produced automatically by the CI nightly workflow.
-          labels: automated,version-bump
+
+      - name: Label version bump PR
+        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
+        continue-on-error: true
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GH_PAT }}
+          script: |
+            const pr = Number('${{ steps.create_pr.outputs.pull-request-number }}');
+            if (!pr) {
+              core.info('No PR number returned; skipping labels.');
+              return;
+            }
+
+            for (let attempt = 1; attempt <= 5; attempt++) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr,
+                  labels: ['automated', 'version-bump']
+                });
+                core.info(`Applied labels to PR #${pr} on attempt ${attempt}.`);
+                return;
+              } catch (error) {
+                if (attempt === 5) {
+                  core.warning(`Failed to label PR #${pr}: ${error.message}`);
+                  return;
+                }
+
+                const delayMs = attempt * 2000;
+                core.warning(`Label attempt ${attempt} failed for PR #${pr}: ${error.message}. Retrying in ${delayMs}ms.`);
+                await new Promise(resolve => setTimeout(resolve, delayMs));
+              }
+            }
 
       - name: Merge version bump PR (skip CI)
+        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
         uses: actions/github-script@v6
         env:
           PR_NUMBER: ${{ steps.create_pr.outputs['pull-request-number'] }}
           NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
         with:
+          github-token: ${{ secrets.GH_PAT }}
           script: |
             const pr = parseInt(process.env.PR_NUMBER, 10);
             if (!pr) throw new Error('PR number missing');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Create Pull Request for version bump (release)
         id: create_pr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GH_PAT }}
           commit-message: "[skip ci] Bump version to ${{ steps.resolve-version.outputs.VERSION }}"
@@ -102,14 +102,50 @@ jobs:
           body: |
             This PR bumps the application version to ${{ steps.resolve-version.outputs.VERSION }}.
             The change was produced automatically by the CI release workflow.
-          labels: automated,version-bump
+
+      - name: Label version bump PR
+        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
+        continue-on-error: true
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GH_PAT }}
+          script: |
+            const pr = Number('${{ steps.create_pr.outputs.pull-request-number }}');
+            if (!pr) {
+              core.info('No PR number returned; skipping labels.');
+              return;
+            }
+
+            for (let attempt = 1; attempt <= 5; attempt++) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr,
+                  labels: ['automated', 'version-bump']
+                });
+                core.info(`Applied labels to PR #${pr} on attempt ${attempt}.`);
+                return;
+              } catch (error) {
+                if (attempt === 5) {
+                  core.warning(`Failed to label PR #${pr}: ${error.message}`);
+                  return;
+                }
+
+                const delayMs = attempt * 2000;
+                core.warning(`Label attempt ${attempt} failed for PR #${pr}: ${error.message}. Retrying in ${delayMs}ms.`);
+                await new Promise(resolve => setTimeout(resolve, delayMs));
+              }
+            }
 
       - name: Merge release version bump PR (skip CI)
+        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
         uses: actions/github-script@v6
         env:
           PR_NUMBER: ${{ steps.create_pr.outputs['pull-request-number'] }}
           NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
         with:
+          github-token: ${{ secrets.GH_PAT }}
           script: |
             const pr = parseInt(process.env.PR_NUMBER, 10);
             if (!pr) throw new Error('PR number missing');

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -8564,9 +8564,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -2957,9 +2957,9 @@
       }
     },
     "node_modules/@vue/language-core/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6783,9 +6783,9 @@
       }
     },
     "node_modules/npm-run-all2/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7184,9 +7184,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7664,9 +7664,9 @@
       }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8346,9 +8346,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8621,9 +8621,9 @@
       }
     },
     "node_modules/unplugin-utils/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8633,9 +8633,9 @@
       }
     },
     "node_modules/unplugin/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9001,9 +9001,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9092,9 +9092,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9261,9 +9261,9 @@
       "license": "MIT"
     },
     "node_modules/vue-router/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -5176,9 +5176,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -45,7 +45,7 @@
         "start-server-and-test": "^2.1.5",
         "typescript": "~5.9.0",
         "vite": "^7.1.11",
-        "vite-plugin-vue-devtools": "^8.0.5",
+        "vite-plugin-vue-devtools": "^8.0.7",
         "vitest": "^4.0.18",
         "vue-tsc": "^3.2.5"
       },
@@ -2835,67 +2835,38 @@
       }
     },
     "node_modules/@vue/devtools-core": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.0.6.tgz",
-      "integrity": "sha512-fN7iVtpSQQdtMORWwVZ1JiIAKriinhD+lCHqPw9Rr252ae2TczILEmW0zcAZifPW8HfYcbFkn+h7Wv6kQQCayw==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.0.7.tgz",
+      "integrity": "sha512-PmpiPxvg3Of80ODHVvyckxwEW1Z02VIAvARIZS1xegINn3VuNQLm9iHUmKD+o6cLkMNWV8OG8x7zo0kgydZgdg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-kit": "^8.0.6",
-        "@vue/devtools-shared": "^8.0.6",
-        "mitt": "^3.0.1",
-        "nanoid": "^5.1.5",
-        "pathe": "^2.0.3",
-        "vite-hot-client": "^2.1.0"
+        "@vue/devtools-kit": "^8.0.7",
+        "@vue/devtools-shared": "^8.0.7"
       },
       "peerDependencies": {
         "vue": "^3.0.0"
       }
     },
     "node_modules/@vue/devtools-core/node_modules/@vue/devtools-kit": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.0.6.tgz",
-      "integrity": "sha512-9zXZPTJW72OteDXeSa5RVML3zWDCRcO5t77aJqSs228mdopYj5AiTpihozbsfFJ0IodfNs7pSgOGO3qfCuxDtw==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.0.7.tgz",
+      "integrity": "sha512-H6esJGHGl5q0E9iV3m2EoBQHJ+V83WMW83A0/+Fn95eZ2iIvdsq4+UCS6yT/Fdd4cGZSchx/MdWDreM3WqMsDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-shared": "^8.0.6",
+        "@vue/devtools-shared": "^8.0.7",
         "birpc": "^2.6.1",
         "hookable": "^5.5.3",
-        "mitt": "^3.0.1",
-        "perfect-debounce": "^2.0.0",
-        "speakingurl": "^14.0.1",
-        "superjson": "^2.2.2"
+        "perfect-debounce": "^2.0.0"
       }
     },
     "node_modules/@vue/devtools-core/node_modules/@vue/devtools-shared": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.0.6.tgz",
-      "integrity": "sha512-Pp1JylTqlgMJvxW6MGyfTF8vGvlBSCAvMFaDCYa82Mgw7TT5eE5kkHgDvmOGHWeJE4zIDfCpCxHapsK2LtIAJg==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.0.7.tgz",
+      "integrity": "sha512-CgAb9oJH5NUmbQRdYDj/1zMiaICYSLtm+B1kxcP72LBrifGAjUmt8bx52dDH1gWRPlQgxGPqpAMKavzVirAEhA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rfdc": "^1.4.1"
-      }
-    },
-    "node_modules/@vue/devtools-core/node_modules/nanoid": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
-      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      }
+      "license": "MIT"
     },
     "node_modules/@vue/devtools-core/node_modules/perfect-debounce": {
       "version": "2.1.0",
@@ -8943,15 +8914,15 @@
       "license": "MIT"
     },
     "node_modules/vite-plugin-vue-devtools": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/vite-plugin-vue-devtools/-/vite-plugin-vue-devtools-8.0.6.tgz",
-      "integrity": "sha512-IiTCIJDb1ZliOT8fPbYXllyfgARzz1+R1r8RN9ScGIDzAB6o8bDME1a9JjrfdSJibL7i8DIPQH+pGv0U7haBeA==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/vite-plugin-vue-devtools/-/vite-plugin-vue-devtools-8.0.7.tgz",
+      "integrity": "sha512-BWj/ykGpqVAJVdPyHmSTUm44buz3jPv+6jnvuFdQSRH0kAgP1cEIE4doHiFyqHXOmuB5EQVR/nh2g9YRiRNs9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-core": "^8.0.6",
-        "@vue/devtools-kit": "^8.0.6",
-        "@vue/devtools-shared": "^8.0.6",
+        "@vue/devtools-core": "^8.0.7",
+        "@vue/devtools-kit": "^8.0.7",
+        "@vue/devtools-shared": "^8.0.7",
         "sirv": "^3.0.2",
         "vite-plugin-inspect": "^11.3.3",
         "vite-plugin-vue-inspector": "^5.3.2"
@@ -8960,34 +8931,28 @@
         "node": ">=v14.21.3"
       },
       "peerDependencies": {
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0-0 || ^8.0.0-0"
       }
     },
     "node_modules/vite-plugin-vue-devtools/node_modules/@vue/devtools-kit": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.0.6.tgz",
-      "integrity": "sha512-9zXZPTJW72OteDXeSa5RVML3zWDCRcO5t77aJqSs228mdopYj5AiTpihozbsfFJ0IodfNs7pSgOGO3qfCuxDtw==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.0.7.tgz",
+      "integrity": "sha512-H6esJGHGl5q0E9iV3m2EoBQHJ+V83WMW83A0/+Fn95eZ2iIvdsq4+UCS6yT/Fdd4cGZSchx/MdWDreM3WqMsDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-shared": "^8.0.6",
+        "@vue/devtools-shared": "^8.0.7",
         "birpc": "^2.6.1",
         "hookable": "^5.5.3",
-        "mitt": "^3.0.1",
-        "perfect-debounce": "^2.0.0",
-        "speakingurl": "^14.0.1",
-        "superjson": "^2.2.2"
+        "perfect-debounce": "^2.0.0"
       }
     },
     "node_modules/vite-plugin-vue-devtools/node_modules/@vue/devtools-shared": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.0.6.tgz",
-      "integrity": "sha512-Pp1JylTqlgMJvxW6MGyfTF8vGvlBSCAvMFaDCYa82Mgw7TT5eE5kkHgDvmOGHWeJE4zIDfCpCxHapsK2LtIAJg==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.0.7.tgz",
+      "integrity": "sha512-CgAb9oJH5NUmbQRdYDj/1zMiaICYSLtm+B1kxcP72LBrifGAjUmt8bx52dDH1gWRPlQgxGPqpAMKavzVirAEhA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rfdc": "^1.4.1"
-      }
+      "license": "MIT"
     },
     "node_modules/vite-plugin-vue-devtools/node_modules/perfect-debounce": {
       "version": "2.1.0",

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -30,7 +30,7 @@
         "@vue/eslint-config-prettier": "^10.2.0",
         "@vue/eslint-config-typescript": "^14.6.0",
         "@vue/test-utils": "^2.4.6",
-        "@vue/tsconfig": "^0.8.1",
+        "@vue/tsconfig": "^0.9.0",
         "concurrently": "^9.2.1",
         "cypress": "^15.11.0",
         "eslint": "^10.0.2",
@@ -3060,9 +3060,9 @@
       }
     },
     "node_modules/@vue/tsconfig": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.8.1.tgz",
-      "integrity": "sha512-aK7feIWPXFSUhsCP9PFqPyFOcz4ENkb8hZ2pneL6m2UjCkccvaOhC/5KCKluuBufvp2KzkbdA2W2pk20vLzu3g==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.9.0.tgz",
+      "integrity": "sha512-RP+v9Cpbsk1ZVXltCHHkYBr7+624x6gcijJXVjIcsYk7JXqvIpRtMwU2ARLvWDhmy9ffdFYxhsfJnPztADBohQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -9554,9 +9554,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/fe/package.json
+++ b/fe/package.json
@@ -64,7 +64,7 @@
     "start-server-and-test": "^2.1.5",
     "typescript": "~5.9.0",
     "vite": "^7.1.11",
-    "vite-plugin-vue-devtools": "^8.0.5",
+    "vite-plugin-vue-devtools": "^8.0.7",
     "vitest": "^4.0.18",
     "vue-tsc": "^3.2.5"
   },

--- a/fe/package.json
+++ b/fe/package.json
@@ -49,7 +49,7 @@
     "@vue/eslint-config-prettier": "^10.2.0",
     "@vue/eslint-config-typescript": "^14.6.0",
     "@vue/test-utils": "^2.4.6",
-    "@vue/tsconfig": "^0.8.1",
+    "@vue/tsconfig": "^0.9.0",
     "concurrently": "^9.2.1",
     "cypress": "^15.11.0",
     "eslint": "^10.0.2",

--- a/fe/src/__tests__/ActivityView.mobile.spec.ts
+++ b/fe/src/__tests__/ActivityView.mobile.spec.ts
@@ -55,6 +55,12 @@ describe('ActivityView mobile virtualization', () => {
       }),
     }))
 
+    vi.doMock('@/stores/library', () => ({
+      useLibraryStore: () => ({
+        audiobooks: [],
+      }),
+    }))
+
     vi.doMock('@/stores/downloads', () => ({
       useDownloadsStore: () => ({
         activeDownloads: [],
@@ -84,9 +90,9 @@ describe('ActivityView mobile virtualization', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 10))
 
-    expect(wrapper.find('.queue-list-container').classes()).toContain('is-static')
-    expect(wrapper.find('.queue-list.is-static').exists()).toBe(true)
-    expect(wrapper.findAll('.queue-item')).toHaveLength(25)
+    expect(wrapper.find('.queue-grid-container').classes()).toContain('is-static')
+    expect(wrapper.find('.queue-body.is-static').exists()).toBe(true)
+    expect(wrapper.findAll('.queue-row')).toHaveLength(25)
 
     wrapper.unmount()
   })

--- a/fe/src/__tests__/ActivityView.spec.ts
+++ b/fe/src/__tests__/ActivityView.spec.ts
@@ -1,8 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount } from '@vue/test-utils'
-import { ref } from 'vue'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
 
-type FilterTab = { value: string; count: number }
 type ActivityItem = {
   id: string
   title?: string
@@ -11,245 +9,150 @@ type ActivityItem = {
   downloadClient?: string
   downloadClientType?: string
   progress?: number
-  totalSize?: number
-  downloadedSize?: number
   canRemove?: boolean
 }
 
-describe('ActivityView Completed tab shows completed downloads from downloads store', () => {
-  beforeEach(() => {
-    vi.resetModules()
+type ActivityViewVm = {
+  allActivityItems: ActivityItem[]
+  filteredQueue: ActivityItem[]
+  filterText: string
+  showRemoveModal: boolean
+  clientHasQueueEntry: boolean | null
+  queueHealthClients: Array<{ name: string; isUnavailable?: boolean }>
+  removeFromQueue: (item: ActivityItem) => Promise<void> | void
+  confirmRemove: () => Promise<void>
+}
+
+const mockSignalR = () => {
+  vi.doMock('@/services/signalr', () => ({
+    signalRService: {
+      onQueueUpdate: vi.fn(() => () => undefined),
+    },
+  }))
+}
+
+const mockApi = (overrides: Record<string, unknown> = {}) => {
+  const apiService = {
+    getQueue: vi.fn(async () => []),
+    removeFromQueue: vi.fn(async () => undefined),
+    cancelDownload: vi.fn(async () => undefined),
+    ...overrides,
+  }
+
+  vi.doMock('@/services/api', () => ({
+    apiService,
+  }))
+
+  return apiService
+}
+
+const mockConfigurationStore = (showCompletedExternalDownloads = false) => {
+  vi.doMock('@/stores/configuration', () => ({
+    useConfigurationStore: () => ({
+      applicationSettings: { showCompletedExternalDownloads },
+      loadApplicationSettings: vi.fn(async () => undefined),
+    }),
+  }))
+}
+
+const mockLibraryStore = (audiobooks: Array<{ id: number; title: string }> = []) => {
+  vi.doMock('@/stores/library', () => ({
+    useLibraryStore: () => ({
+      audiobooks,
+    }),
+  }))
+}
+
+const mockDownloadsStore = (overrides: Record<string, unknown> = {}) => {
+  const store = {
+    activeDownloads: [],
+    completedDownloads: [],
+    failedDownloads: [],
+    loadDownloads: vi.fn(async () => undefined),
+    ...overrides,
+  }
+
+  vi.doMock('@/stores/downloads', () => ({
+    useDownloadsStore: () => store,
+  }))
+
+  return store
+}
+
+const mountActivityView = async () => {
+  const { default: ActivityViewComponent } = await import('@/views/activity/ActivityView.vue')
+  const wrapper = mount(ActivityViewComponent, {
+    global: {
+      stubs: {
+        CustomSelect: true,
+        RouterLink: { template: '<a><slot /></a>' },
+      },
+    },
   })
 
-  it('includes completed external downloads from downloads store in Completed tab', async () => {
-    // Reset module registry and stub all runtime dependencies so the component
-    // doesn't attempt to connect to real services. Use doMock after reset.
+  await flushPromises()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  return wrapper
+}
+
+describe('ActivityView', () => {
+  beforeEach(() => {
     vi.resetModules()
+    vi.clearAllMocks()
+    vi.spyOn(globalThis, 'setInterval').mockReturnValue(1 as unknown as ReturnType<typeof setInterval>)
+    vi.spyOn(globalThis, 'clearInterval').mockImplementation(() => undefined)
+  })
 
-    // Stub out SignalR and API
-    vi.doMock('@/services/signalr', () => ({
-      signalRService: {
-        connect: vi.fn(async () => undefined),
-        onQueueUpdate: vi.fn(() => () => undefined),
-        onFilesRemoved: vi.fn(() => () => undefined),
-        onToast: vi.fn(() => () => undefined),
-        onAudiobookUpdate: vi.fn(() => () => undefined),
-        onDownloadUpdate: vi.fn(() => () => undefined),
-        onDownloadsList: vi.fn(() => () => undefined),
-      },
-    }))
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
 
-    vi.doMock('@/services/api', () => ({
-      apiService: {
-        getQueue: async () => [],
-        getServiceHealth: async () => ({ version: '0.0.0' }),
-        getStartupConfig: async () => ({ authenticationRequired: false }),
-        getLibrary: async () => [],
-      },
-    }))
+  it('includes completed external downloads from the downloads store in the unified list', async () => {
+    mockSignalR()
+    mockApi()
+    mockConfigurationStore(false)
+    mockLibraryStore()
+    mockDownloadsStore({
+      completedDownloads: [
+        { id: 'd1', status: 'Completed', progress: 100, downloadClientId: 'SABnzbd', startedAt: new Date().toISOString(), title: 'One', downloadedSize: 1000, totalSize: 1000 },
+        { id: 'd2', status: 'Completed', progress: 100, downloadClientId: 'qbittorrent', startedAt: new Date().toISOString(), title: 'Two', downloadedSize: 2000, totalSize: 2000 },
+        { id: 'd3', status: 'Completed', progress: 100, downloadClientId: 'transmission', startedAt: new Date().toISOString(), title: 'Three', downloadedSize: 3000, totalSize: 3000 },
+        { id: 'd4', status: 'Completed', progress: 100, downloadClientId: 'nzbget', startedAt: new Date().toISOString(), title: 'Four', downloadedSize: 4000, totalSize: 4000 },
+      ],
+    })
 
-    // Provide minimal configuration store stub - default to hide completed external downloads
-    vi.doMock('@/stores/configuration', () => ({
-      useConfigurationStore: () => ({
-        applicationSettings: { showCompletedExternalDownloads: false },
-        loadApplicationSettings: vi.fn(async () => undefined),
-      }),
-    }))
+    const wrapper = await mountActivityView()
+    const vm = wrapper.vm as unknown as ActivityViewVm
 
-    // Provide a downloads store with 4 completed external downloads
-    const completed = ref([
-      {
-        id: 'd1',
-        status: 'Completed',
-        progress: 100,
-        downloadClientId: 'SABnzbd',
-        startedAt: new Date().toISOString(),
-        title: 'One',
-        downloadedSize: 1000,
-        totalSize: 1000,
-      },
-      {
-        id: 'd2',
-        status: 'Completed',
-        progress: 100,
-        downloadClientId: 'qbittorrent',
-        startedAt: new Date().toISOString(),
-        title: 'Two',
-        downloadedSize: 2000,
-        totalSize: 2000,
-      },
-      {
-        id: 'd3',
-        status: 'Completed',
-        progress: 100,
-        downloadClientId: 'transmission',
-        startedAt: new Date().toISOString(),
-        title: 'Three',
-        downloadedSize: 3000,
-        totalSize: 3000,
-      },
-      {
-        id: 'd4',
-        status: 'Completed',
-        progress: 100,
-        downloadClientId: 'nzbget',
-        startedAt: new Date().toISOString(),
-        title: 'Four',
-        downloadedSize: 4000,
-        totalSize: 4000,
-      },
-    ])
+    expect(vm.allActivityItems.map((item) => item.id)).toEqual(
+      expect.arrayContaining(['d1', 'd2', 'd3', 'd4']),
+    )
+    expect(vm.filteredQueue).toHaveLength(4)
+  })
 
-    vi.doMock('@/stores/downloads', () => ({
-      useDownloadsStore: () => ({
-        // Mirror runtime unwrapped values: provide arrays directly so
-        // ActivityView's `.filter`/`.map` calls work during tests
-        activeDownloads: [],
-        completedDownloads: completed.value,
-        loadDownloads: vi.fn(async () => undefined),
-      }),
-    }))
+  it('filters the unified activity list by text', async () => {
+    mockSignalR()
+    mockApi()
+    mockConfigurationStore(true)
+    mockLibraryStore()
+    mockDownloadsStore({
+      completedDownloads: [
+        { id: 'd1', status: 'Completed', progress: 100, downloadClientId: 'SABnzbd', startedAt: new Date().toISOString(), title: 'One', downloadedSize: 1000, totalSize: 1000 },
+        { id: 'd2', status: 'Completed', progress: 100, downloadClientId: 'qbittorrent', startedAt: new Date().toISOString(), title: 'Two', downloadedSize: 2000, totalSize: 2000 },
+      ],
+    })
 
-    console.log('[TEST] importing ActivityView')
-    const { default: ActivityViewComponent } = await import('@/views/activity/ActivityView.vue')
-    console.log('[TEST] imported ActivityView, now mounting')
+    const wrapper = await mountActivityView()
+    const vm = wrapper.vm as unknown as ActivityViewVm
 
-    const wrapper = mount(ActivityViewComponent, { global: { stubs: ['CustomSelect'] } })
-    console.log('[TEST] mounted ActivityView')
+    vm.filterText = 'two'
+    await flushPromises()
 
-    // Ensure initial state computed values are ready
-    await new Promise((r) => setTimeout(r, 10))
-    console.log('[TEST] after initial tick')
+    expect(vm.filteredQueue).toHaveLength(1)
+    expect(vm.filteredQueue[0]?.id).toBe('d2')
+  })
 
-    // Completed tab should show 4 items from completedDownloads even though queue is empty
-    // Select the Completed tab via component instance so composition API refs update
-    const vm = wrapper.vm as unknown as {
-      selectedTab: string
-      filteredQueue: ActivityItem[]
-      filterTabs: FilterTab[]
-    }
-    vm.selectedTab = 'completed'
-    // Wait a tick for reactivity
-    await new Promise((r) => setTimeout(r, 10))
-    console.log('[TEST] after selecting tab and waiting')
-
-    // filteredQueue computed should reflect the 4 items
-    expect(vm.filteredQueue.length).toBe(4)
-
-    // The completed count in filterTabs should reflect 4
-    const completedTab = vm.filterTabs.find((t) => t.value === 'completed')
-    expect(completedTab!.count).toBe(4)
-
-    // All tab should not include these completed external items by default (unless user pref set)
-    const allCount = vm.filterTabs.find((t) => t.value === 'all')!.count
-    expect(allCount).toBeGreaterThanOrEqual(0)
-  }, 20000)
-
-  it('All tab includes completed external downloads when preference enabled', async () => {
-    vi.resetModules()
-
-    // Mock signalr and API (same stubs as other tests)
-    vi.doMock('@/services/signalr', () => ({
-      signalRService: {
-        connect: vi.fn(async () => undefined),
-        onQueueUpdate: vi.fn(() => () => undefined),
-        onFilesRemoved: vi.fn(() => () => undefined),
-        onToast: vi.fn(() => () => undefined),
-        onAudiobookUpdate: vi.fn(() => () => undefined),
-        onDownloadUpdate: vi.fn(() => () => undefined),
-        onDownloadsList: vi.fn(() => () => undefined),
-      },
-    }))
-
-    vi.doMock('@/services/api', () => ({
-      apiService: {
-        getQueue: async () => [],
-        getServiceHealth: async () => ({ version: '0.0.0' }),
-        getStartupConfig: async () => ({ authenticationRequired: false }),
-        getLibrary: async () => [],
-      },
-    }))
-
-    // Provide configuration store stub enabling showCompletedExternalDownloads
-    vi.doMock('@/stores/configuration', () => ({
-      useConfigurationStore: () => ({
-        applicationSettings: { showCompletedExternalDownloads: true },
-        loadApplicationSettings: vi.fn(async () => undefined),
-      }),
-    }))
-
-    // Provide a downloads store with 4 completed external downloads
-    const completed = ref([
-      {
-        id: 'd1',
-        status: 'Completed',
-        progress: 100,
-        downloadClientId: 'SABnzbd',
-        startedAt: new Date().toISOString(),
-        title: 'One',
-        downloadedSize: 1000,
-        totalSize: 1000,
-      },
-      {
-        id: 'd2',
-        status: 'Completed',
-        progress: 100,
-        downloadClientId: 'qbittorrent',
-        startedAt: new Date().toISOString(),
-        title: 'Two',
-        downloadedSize: 2000,
-        totalSize: 2000,
-      },
-      {
-        id: 'd3',
-        status: 'Completed',
-        progress: 100,
-        downloadClientId: 'transmission',
-        startedAt: new Date().toISOString(),
-        title: 'Three',
-        downloadedSize: 3000,
-        totalSize: 3000,
-      },
-      {
-        id: 'd4',
-        status: 'Completed',
-        progress: 100,
-        downloadClientId: 'nzbget',
-        startedAt: new Date().toISOString(),
-        title: 'Four',
-        downloadedSize: 4000,
-        totalSize: 4000,
-      },
-    ])
-
-    vi.doMock('@/stores/downloads', () => ({
-      useDownloadsStore: () => ({
-        activeDownloads: [],
-        completedDownloads: completed.value,
-        loadDownloads: vi.fn(async () => undefined),
-      }),
-    }))
-
-    const { default: ActivityViewComponent } = await import('@/views/activity/ActivityView.vue')
-    const wrapper = mount(ActivityViewComponent, { global: { stubs: ['CustomSelect'] } })
-
-    // Wait for mounted hooks and reactivity
-    await new Promise((r) => setTimeout(r, 10))
-
-    const vm = wrapper.vm as unknown as {
-      allActivityItems: ActivityItem[]
-      filterTabs: FilterTab[]
-    }
-    const allItems = vm.allActivityItems
-    expect(allItems.some((i) => i.id === 'd1')).toBe(true)
-
-    const allTab = vm.filterTabs.find((t) => t.value === 'all')
-    expect(allTab!.count).toBeGreaterThanOrEqual(4)
-  }, 20000)
-
-  it('removes an item from client when it exists in queue', async () => {
-    vi.resetModules()
-
+  it('removes a queue-backed item from the client', async () => {
     const queueItem = {
       id: 'q1',
       title: 'Queue Item',
@@ -262,839 +165,252 @@ describe('ActivityView Completed tab shows completed downloads from downloads st
       canRemove: true,
     }
 
-    // Mock signalr and API
-    vi.doMock('@/services/signalr', () => ({
-      signalRService: {
-        connect: vi.fn(async () => undefined),
-        onQueueUpdate: vi.fn(() => () => undefined),
-        onFilesRemoved: vi.fn(() => () => undefined),
-        onToast: vi.fn(() => () => undefined),
-        onAudiobookUpdate: vi.fn(() => () => undefined),
-        onDownloadUpdate: vi.fn(() => () => undefined),
-        onDownloadsList: vi.fn(() => () => undefined),
-      },
-    }))
+    mockSignalR()
+    const apiService = mockApi({
+      getQueue: vi.fn(async () => [queueItem]),
+    })
+    mockConfigurationStore(false)
+    mockLibraryStore()
+    mockDownloadsStore()
 
-    const removeFromQueueMock = vi.fn(async () => undefined)
-    const getQueueMock = vi.fn(async () => [queueItem])
+    const wrapper = await mountActivityView()
+    const vm = wrapper.vm as unknown as ActivityViewVm
+    const item = vm.allActivityItems.find((entry) => entry.id === 'q1')
 
-    vi.doMock('@/services/api', () => ({
-      apiService: {
-        getQueue: getQueueMock,
-        removeFromQueue: removeFromQueueMock,
-        cancelDownload: vi.fn(async () => undefined),
-        getServiceHealth: async () => ({ version: '0.0.0' }),
-        getStartupConfig: async () => ({ authenticationRequired: false }),
-        getLibrary: async () => [],
-      },
-    }))
+    expect(item).toBeDefined()
 
-    // Use default config and empty downloads store
-    vi.doMock('@/stores/configuration', () => ({
-      useConfigurationStore: () => ({
-        applicationSettings: { showCompletedExternalDownloads: false },
-        loadApplicationSettings: vi.fn(async () => undefined),
-      }),
-    }))
-
-    vi.doMock('@/stores/downloads', () => ({
-      useDownloadsStore: () => ({
-        activeDownloads: [],
-        completedDownloads: [],
-        loadDownloads: vi.fn(async () => undefined),
-      }),
-    }))
-
-    const { default: ActivityViewComponent } = await import('@/views/activity/ActivityView.vue')
-    const wrapper = mount(ActivityViewComponent, { global: { stubs: ['CustomSelect'] } })
-
-    // Wait for mounted hooks (getQueue) to finish
-    await new Promise((r) => setTimeout(r, 10))
-
-    const vm = wrapper.vm as unknown as {
-      allActivityItems: ActivityItem[]
-      removeFromQueue: (i?: ActivityItem | undefined) => void
-      showRemoveModal: boolean
-      clientHasQueueEntry: boolean
-      confirmRemove: () => Promise<void>
-    }
-
-    // There should be a queue item
-    const items = vm.allActivityItems
-    expect(items.some((i) => i.id === 'q1')).toBe(true)
-
-    // Trigger remove flow
-    const item = items.find((i) => i.id === 'q1')
-    vm.removeFromQueue(item)
-
+    await vm.removeFromQueue(item!)
     expect(vm.showRemoveModal).toBe(true)
     expect(vm.clientHasQueueEntry).toBe(true)
 
-    // Confirm remove should call removeFromQueue API for client
     await vm.confirmRemove()
+    expect(apiService.removeFromQueue).toHaveBeenCalledWith('q1', 'qbittorrent')
+  })
 
-    expect(removeFromQueueMock).toHaveBeenCalledWith('q1', 'qbittorrent')
-  }, 20000)
+  it('offers Listenarr-only removal when an external item is no longer in the client queue', async () => {
+    mockSignalR()
+    const apiService = mockApi({
+      getQueue: vi.fn(async () => []),
+    })
+    mockConfigurationStore(false)
+    mockLibraryStore()
+    const downloadsStore = mockDownloadsStore({
+      completedDownloads: [
+        {
+          id: 'ext-1',
+          status: 'Completed',
+          progress: 100,
+          downloadClientId: 'SABnzbd',
+          startedAt: new Date().toISOString(),
+          title: 'Completed External',
+          downloadedSize: 100,
+          totalSize: 100,
+        },
+      ],
+    })
 
-  it('offers Listenarr-only removal when item is not in client queue', async () => {
-    vi.resetModules()
+    const wrapper = await mountActivityView()
+    const vm = wrapper.vm as unknown as ActivityViewVm
+    const item = vm.allActivityItems.find((entry) => entry.id === 'ext-1')
 
-    // No queue entries
-    vi.doMock('@/services/signalr', () => ({
-      signalRService: {
-        connect: vi.fn(async () => undefined),
-        onQueueUpdate: vi.fn(() => () => undefined),
-        onFilesRemoved: vi.fn(() => () => undefined),
-        onToast: vi.fn(() => () => undefined),
-        onAudiobookUpdate: vi.fn(() => () => undefined),
-        onDownloadUpdate: vi.fn(() => () => undefined),
-        onDownloadsList: vi.fn(() => () => undefined),
-      },
-    }))
+    expect(item).toBeDefined()
 
-    const getQueueMock = vi.fn(async () => [])
-    const cancelDownloadMock = vi.fn(async () => undefined)
-
-    vi.doMock('@/services/api', () => ({
-      apiService: {
-        getQueue: getQueueMock,
-        removeFromQueue: vi.fn(async () => undefined),
-        cancelDownload: cancelDownloadMock,
-        getServiceHealth: async () => ({ version: '0.0.0' }),
-        getStartupConfig: async () => ({ authenticationRequired: false }),
-        getLibrary: async () => [],
-      },
-    }))
-
-    // Configuration
-    vi.doMock('@/stores/configuration', () => ({
-      useConfigurationStore: () => ({
-        applicationSettings: { showCompletedExternalDownloads: false },
-        loadApplicationSettings: vi.fn(async () => undefined),
-      }),
-    }))
-
-    // Provide a completed external download (e.g., saved candidate) that isn't in the queue
-    const completed = [
-      {
-        id: 'ext-1',
-        status: 'Completed',
-        progress: 100,
-        downloadClientId: 'SABnzbd',
-        startedAt: new Date().toISOString(),
-        title: 'Completed External',
-        downloadedSize: 100,
-        totalSize: 100,
-      },
-    ]
-
-    const loadDownloadsMock = vi.fn(async () => undefined)
-
-    vi.doMock('@/stores/downloads', () => ({
-      useDownloadsStore: () => ({
-        activeDownloads: [],
-        completedDownloads: completed,
-        loadDownloads: loadDownloadsMock,
-      }),
-    }))
-
-    const { default: ActivityViewComponent } = await import('@/views/activity/ActivityView.vue')
-    const wrapper = mount(ActivityViewComponent, { global: { stubs: ['CustomSelect'] } })
-
-    // Wait for mounted hooks
-    await new Promise((r) => setTimeout(r, 10))
-
-    const vm = wrapper.vm as unknown as {
-      selectedTab: string
-      filteredQueue: ActivityItem[]
-      removeFromQueue: (i?: ActivityItem) => void
-      showRemoveModal: boolean
-      clientHasQueueEntry: boolean
-      confirmRemove: () => Promise<void>
-    }
-
-    // Switch to Completed tab and find the completed item
-    vm.selectedTab = 'completed'
-    await new Promise((r) => setTimeout(r, 10))
-
-    const completedItems = vm.filteredQueue
-    expect(completedItems.some((i) => i.id === 'ext-1')).toBe(true)
-
-    // Trigger remove on the completed external item
-    const item = completedItems.find((i) => i.id === 'ext-1')
-    vm.removeFromQueue(item)
-
+    await vm.removeFromQueue(item!)
     expect(vm.showRemoveModal).toBe(true)
-    // Since getQueue returned empty, clientHasQueueEntry should be false
     expect(vm.clientHasQueueEntry).toBe(false)
 
-    // Confirm remove should call cancelDownload (Listenarr-only removal) and reload downloads
     await vm.confirmRemove()
-    expect(cancelDownloadMock).toHaveBeenCalledWith('ext-1')
-    expect(loadDownloadsMock).toHaveBeenCalled()
-  }, 20000)
-
-  it('removes an external item from client when it exists in the remote queue', async () => {
-    vi.resetModules()
-
-    const queueItem = {
-      id: 'q1',
-      title: 'Queue Item',
-      status: 'downloading',
-      progress: 50,
-      totalSize: 1000,
-      downloadedSize: 500,
-      downloadClientId: 'SABnzbd',
-      downloadClient: 'SABnzbd',
-      downloadClientType: 'external',
-    }
-
-    vi.doMock('@/services/signalr', () => ({
-      signalRService: {
-        connect: vi.fn(async () => undefined),
-        onQueueUpdate: vi.fn(() => () => undefined),
-        onFilesRemoved: vi.fn(() => () => undefined),
-        onToast: vi.fn(() => () => undefined),
-        onAudiobookUpdate: vi.fn(() => () => undefined),
-        onDownloadUpdate: vi.fn(() => () => undefined),
-        onDownloadsList: vi.fn(() => () => undefined),
-      },
-    }))
-
-    const removeFromQueueMock = vi.fn(async () => undefined)
-    const cancelDownloadMock = vi.fn(async () => undefined)
-    const getQueueMock = vi.fn(async () => [queueItem])
-
-    vi.doMock('@/services/api', () => ({
-      apiService: {
-        getQueue: getQueueMock,
-        removeFromQueue: removeFromQueueMock,
-        cancelDownload: cancelDownloadMock,
-        getServiceHealth: async () => ({ version: '0.0.0' }),
-        getStartupConfig: async () => ({ authenticationRequired: false }),
-        getLibrary: async () => [],
-      },
-    }))
-
-    vi.doMock('@/stores/configuration', () => ({
-      useConfigurationStore: () => ({
-        applicationSettings: { showCompletedExternalDownloads: false },
-        loadApplicationSettings: vi.fn(async () => undefined),
-      }),
-    }))
-
-    const loadDownloadsMock = vi.fn(async () => undefined)
-    vi.doMock('@/stores/downloads', () => ({
-      useDownloadsStore: () => ({
-        activeDownloads: [],
-        completedDownloads: [],
-        loadDownloads: loadDownloadsMock,
-      }),
-    }))
-
-    const { default: ActivityViewComponent } = await import('@/views/activity/ActivityView.vue')
-    const wrapper = mount(ActivityViewComponent, { global: { stubs: ['CustomSelect'] } })
-
-    const vm = wrapper.vm as unknown as {
-      queue: ActivityItem[]
-      removeFromQueue: (i?: ActivityItem) => void
-      clientHasQueueEntry: boolean
-      confirmRemove: () => Promise<void>
-    }
-
-    // Simulate current queue containing the item
-    vm.queue = [queueItem]
-
-    // Trigger remove flow
-    vm.removeFromQueue(queueItem)
-
-    // Pre-check should have found it in the queue
-    expect(vm.clientHasQueueEntry).toBe(true)
-
-    // Confirm removal - should call the client remove endpoint
-    await vm.confirmRemove()
-
-    expect(removeFromQueueMock).toHaveBeenCalledWith('q1', 'SABnzbd')
+    expect(apiService.cancelDownload).toHaveBeenCalledWith('ext-1')
+    expect(downloadsStore.loadDownloads).toHaveBeenCalled()
   })
 
-  it('removes an external item from Listenarr (DB) when it is not in the remote queue', async () => {
-    vi.resetModules()
-
-    const externalItem = {
-      id: 'q2',
-      title: 'Missing Item',
-      status: 'completed',
-      progress: 100,
-      totalSize: 2000,
-      downloadedSize: 2000,
-      downloadClientId: 'SABnzbd',
-      downloadClient: 'SABnzbd',
-      downloadClientType: 'external',
-    }
-
-    vi.doMock('@/services/signalr', () => ({
-      signalRService: {
-        connect: vi.fn(async () => undefined),
-        onQueueUpdate: vi.fn(() => () => undefined),
-        onFilesRemoved: vi.fn(() => () => undefined),
-        onToast: vi.fn(() => () => undefined),
-        onAudiobookUpdate: vi.fn(() => () => undefined),
-        onDownloadUpdate: vi.fn(() => () => undefined),
-        onDownloadsList: vi.fn(() => () => undefined),
-      },
-    }))
-
-    const removeFromQueueMock = vi.fn(async () => undefined)
-    const cancelDownloadMock = vi.fn(async () => undefined)
-    const getQueueMock = vi.fn(async () => [])
-
-    vi.doMock('@/services/api', () => ({
-      apiService: {
-        getQueue: getQueueMock,
-        removeFromQueue: removeFromQueueMock,
-        cancelDownload: cancelDownloadMock,
-        getServiceHealth: async () => ({ version: '0.0.0' }),
-        getStartupConfig: async () => ({ authenticationRequired: false }),
-        getLibrary: async () => [],
-      },
-    }))
-
-    vi.doMock('@/stores/configuration', () => ({
-      useConfigurationStore: () => ({
-        applicationSettings: { showCompletedExternalDownloads: false },
-        loadApplicationSettings: vi.fn(async () => undefined),
-      }),
-    }))
-
-    const loadDownloadsMock = vi.fn(async () => undefined)
-    vi.doMock('@/stores/downloads', () => ({
-      useDownloadsStore: () => ({
-        activeDownloads: [],
-        completedDownloads: [],
-        loadDownloads: loadDownloadsMock,
-      }),
-    }))
-
-    const { default: ActivityViewComponent } = await import('@/views/activity/ActivityView.vue')
-    const wrapper = mount(ActivityViewComponent, { global: { stubs: ['CustomSelect'] } })
-
-    const vm = wrapper.vm as unknown as {
-      queue: ActivityItem[]
-      removeFromQueue: (i?: ActivityItem) => void
-      clientHasQueueEntry: boolean
-      confirmRemove: () => Promise<void>
-    }
-
-    // No queue items present - simulate missing in remote client
-    vm.queue = []
-
-    // Trigger remove flow for the external item
-    vm.removeFromQueue(externalItem)
-
-    // Pre-check should indicate not present in client
-    expect(vm.clientHasQueueEntry).toBe(false)
-
-    // Confirm removal - should call the Listenarr-only cancel path
-    await vm.confirmRemove()
-
-    expect(cancelDownloadMock).toHaveBeenCalledWith('q2')
-    expect(loadDownloadsMock).toHaveBeenCalled()
-  })
-
-  it('Failed tab shows DB failures and queue failures (deduplicated)', async () => {
-    vi.resetModules()
-
+  it('deduplicates failed queue items against failed download records', async () => {
     const queueFailed = {
       id: 'q1',
       title: 'Queue Failed',
       status: 'failed',
       progress: 0,
-      totalSize: 0,
+      size: 0,
       downloaded: 0,
       downloadClientId: 'qbittorrent',
       downloadClient: 'qbittorrent',
     }
 
-    // signalr + api
-    vi.doMock('@/services/signalr', () => ({
-      signalRService: {
-        connect: vi.fn(async () => undefined),
-        onQueueUpdate: vi.fn(() => () => undefined),
-        onFilesRemoved: vi.fn(() => () => undefined),
-        onToast: vi.fn(() => () => undefined),
-        onAudiobookUpdate: vi.fn(() => () => undefined),
-        onDownloadUpdate: vi.fn(() => () => undefined),
-        onDownloadsList: vi.fn(() => () => undefined),
-      },
-    }))
+    mockSignalR()
+    mockApi({
+      getQueue: vi.fn(async () => [queueFailed]),
+    })
+    mockConfigurationStore(false)
+    mockLibraryStore()
+    mockDownloadsStore({
+      failedDownloads: [
+        { id: 'q1', status: 'Failed', progress: 0, downloadClientId: 'qbittorrent', title: 'Queue Failed (DB copy)' },
+        { id: 'd1', status: 'Failed', progress: 0, downloadClientId: 'DDL', title: 'DDL Failed' },
+      ],
+    })
 
-    vi.doMock('@/services/api', () => ({
-      apiService: {
-        getQueue: async () => [queueFailed],
-        getServiceHealth: async () => ({ version: '0.0.0' }),
-        getStartupConfig: async () => ({ authenticationRequired: false }),
-        getLibrary: async () => [],
-      },
-    }))
+    const wrapper = await mountActivityView()
+    const vm = wrapper.vm as unknown as ActivityViewVm
 
-    // failed downloads from DB includes a duplicate id 'q1' and an extra 'd1'
-    const failed = [
-      {
-        id: 'q1',
-        status: 'Failed',
-        progress: 0,
-        downloadClientId: 'qbittorrent',
-        title: 'Queue Failed (DB copy)',
-      },
-      { id: 'd1', status: 'Failed', progress: 0, downloadClientId: 'DDL', title: 'DDL Failed' },
-    ]
+    expect(vm.allActivityItems).toHaveLength(2)
+    expect(vm.allActivityItems.filter((item) => item.id === 'q1')).toHaveLength(1)
+    expect(vm.allActivityItems.some((item) => item.id === 'd1')).toBe(true)
+  })
 
-    vi.doMock('@/stores/configuration', () => ({
-      useConfigurationStore: () => ({
-        applicationSettings: { showCompletedExternalDownloads: false },
-        loadApplicationSettings: vi.fn(async () => undefined),
-      }),
-    }))
+  it('removes a failed DDL download through Listenarr cancellation', async () => {
+    mockSignalR()
+    const apiService = mockApi()
+    mockConfigurationStore(false)
+    mockLibraryStore()
+    const downloadsStore = mockDownloadsStore({
+      failedDownloads: [
+        { id: 'd1', status: 'Failed', progress: 0, downloadClientId: 'DDL', title: 'DDL Failed' },
+      ],
+    })
 
-    vi.doMock('@/stores/downloads', () => ({
-      useDownloadsStore: () => ({
-        activeDownloads: [],
-        failedDownloads: failed,
-        loadDownloads: vi.fn(async () => undefined),
-      }),
-    }))
+    const wrapper = await mountActivityView()
+    const vm = wrapper.vm as unknown as ActivityViewVm
+    const item = vm.allActivityItems.find((entry) => entry.id === 'd1')
 
-    const { default: ActivityViewComponent } = await import('@/views/activity/ActivityView.vue')
-    const wrapper = mount(ActivityViewComponent, { global: { stubs: ['CustomSelect'] } })
+    expect(item).toBeDefined()
 
-    // Wait for mounted hooks
-    await new Promise((r) => setTimeout(r, 10))
-
-    const vm = wrapper.vm as unknown as {
-      selectedTab: string
-      filteredQueue: ActivityItem[]
-      filterTabs: FilterTab[]
-    }
-
-    // Select failed tab
-    vm.selectedTab = 'failed'
-    await new Promise((r) => setTimeout(r, 10))
-
-    const failedItems = vm.filteredQueue
-    // We expect 2 unique failed items (q1 deduped, and d1)
-    expect(failedItems.length).toBe(2)
-
-    const failedTab = vm.filterTabs.find((t) => t.value === 'failed')
-    expect(failedTab!.count).toBe(2)
-  }, 20000)
-
-  it('Removing a DDL failed download uses cancelDownload and reloads downloads', async () => {
-    vi.resetModules()
-
-    vi.doMock('@/services/signalr', () => ({
-      signalRService: {
-        connect: vi.fn(async () => undefined),
-        onQueueUpdate: vi.fn(() => () => undefined),
-        onFilesRemoved: vi.fn(() => () => undefined),
-        onToast: vi.fn(() => () => undefined),
-        onAudiobookUpdate: vi.fn(() => () => undefined),
-        onDownloadUpdate: vi.fn(() => () => undefined),
-        onDownloadsList: vi.fn(() => () => undefined),
-      },
-    }))
-
-    const cancelDownloadMock = vi.fn(async () => undefined)
-    vi.doMock('@/services/api', () => ({
-      apiService: {
-        getQueue: async () => [],
-        removeFromQueue: vi.fn(async () => undefined),
-        cancelDownload: cancelDownloadMock,
-        getServiceHealth: async () => ({ version: '0.0.0' }),
-        getStartupConfig: async () => ({ authenticationRequired: false }),
-        getLibrary: async () => [],
-      },
-    }))
-
-    const loadDownloadsMock = vi.fn(async () => undefined)
-    vi.doMock('@/stores/configuration', () => ({
-      useConfigurationStore: () => ({
-        applicationSettings: { showCompletedExternalDownloads: false },
-        loadApplicationSettings: vi.fn(async () => undefined),
-      }),
-    }))
-    vi.doMock('@/stores/downloads', () => ({
-      useDownloadsStore: () => ({
-        activeDownloads: [],
-        failedDownloads: [
-          { id: 'd1', status: 'Failed', progress: 0, downloadClientId: 'DDL', title: 'DDL Failed' },
-        ],
-        loadDownloads: loadDownloadsMock,
-      }),
-    }))
-
-    const { default: ActivityViewComponent } = await import('@/views/activity/ActivityView.vue')
-    const wrapper = mount(ActivityViewComponent, { global: { stubs: ['CustomSelect'] } })
-
-    // Wait for mounted hooks
-    await new Promise((r) => setTimeout(r, 10))
-
-    const vm = wrapper.vm as unknown as {
-      selectedTab: string
-      filteredQueue: ActivityItem[]
-      removeFromQueue: (i?: ActivityItem) => void
-      showRemoveModal: boolean
-      clientHasQueueEntry: boolean
-      confirmRemove: () => Promise<void>
-    }
-
-    // Select failed tab and remove
-    vm.selectedTab = 'failed'
-    await new Promise((r) => setTimeout(r, 10))
-
-    const failedItems = vm.filteredQueue
-    const item = failedItems.find((i) => i.id === 'd1')
-
-    vm.removeFromQueue(item)
-    expect(vm.showRemoveModal).toBe(true)
-
-    // For DDL, clientHasQueueEntry should be treated as present
+    await vm.removeFromQueue(item!)
     expect(vm.clientHasQueueEntry).toBe(true)
 
     await vm.confirmRemove()
-    expect(cancelDownloadMock).toHaveBeenCalledWith('d1')
-    expect(loadDownloadsMock).toHaveBeenCalled()
-  }, 20000)
+    expect(apiService.cancelDownload).toHaveBeenCalledWith('d1')
+    expect(downloadsStore.loadDownloads).toHaveBeenCalled()
+  })
 
-  it('Removing a failed external queue item calls removeFromQueue on client', async () => {
-    vi.resetModules()
+  it('maps ImportPending and ImportBlocked downloads to activity rows', async () => {
+    mockSignalR()
+    mockApi()
+    mockConfigurationStore(false)
+    mockLibraryStore()
+    mockDownloadsStore({
+      activeDownloads: [
+        {
+          id: 'd-importpending',
+          title: 'Import Pending',
+          status: 'ImportPending',
+          progress: 99,
+          totalSize: 1000,
+          downloadedSize: 990,
+          downloadClientId: 'qbittorrent',
+          startedAt: new Date().toISOString(),
+        },
+      ],
+      failedDownloads: [
+        {
+          id: 'd-importblocked',
+          title: 'Import Blocked',
+          status: 'ImportBlocked',
+          progress: 100,
+          totalSize: 1000,
+          downloadedSize: 1000,
+          downloadClientId: 'qbittorrent',
+          startedAt: new Date().toISOString(),
+        },
+      ],
+    })
 
-    const queueFailed = {
-      id: 'q2',
-      title: 'Queue Failed Q2',
-      status: 'failed',
-      progress: 0,
-      totalSize: 0,
-      downloaded: 0,
-      downloadClientId: 'qbittorrent',
-      downloadClient: 'qbittorrent',
-    }
+    const wrapper = await mountActivityView()
+    const vm = wrapper.vm as unknown as ActivityViewVm
 
-    vi.doMock('@/services/signalr', () => ({
-      signalRService: {
-        connect: vi.fn(async () => undefined),
-        onQueueUpdate: vi.fn(() => () => undefined),
-        onFilesRemoved: vi.fn(() => () => undefined),
-        onToast: vi.fn(() => () => undefined),
-        onAudiobookUpdate: vi.fn(() => () => undefined),
-        onDownloadUpdate: vi.fn(() => () => undefined),
-        onDownloadsList: vi.fn(() => () => undefined),
-      },
-    }))
-
-    const removeFromQueueMock = vi.fn(async () => undefined)
-    vi.doMock('@/services/api', () => ({
-      apiService: {
-        getQueue: async () => [queueFailed],
-        removeFromQueue: removeFromQueueMock,
-        cancelDownload: vi.fn(async () => undefined),
-        getServiceHealth: async () => ({ version: '0.0.0' }),
-        getStartupConfig: async () => ({ authenticationRequired: false }),
-        getLibrary: async () => [],
-      },
-    }))
-
-    vi.doMock('@/stores/configuration', () => ({
-      useConfigurationStore: () => ({
-        applicationSettings: { showCompletedExternalDownloads: false },
-        loadApplicationSettings: vi.fn(async () => undefined),
-      }),
-    }))
-    vi.doMock('@/stores/downloads', () => ({
-      useDownloadsStore: () => ({
-        activeDownloads: [],
-        failedDownloads: [],
-        loadDownloads: vi.fn(async () => undefined),
-      }),
-    }))
-
-    const { default: ActivityViewComponent } = await import('@/views/activity/ActivityView.vue')
-    const wrapper = mount(ActivityViewComponent, { global: { stubs: ['CustomSelect'] } })
-
-    // Wait for mounted hooks and queue load
-    await new Promise((r) => setTimeout(r, 10))
-
-    const vm = wrapper.vm as unknown as {
-      selectedTab: string
-      filteredQueue: ActivityItem[]
-      removeFromQueue: (i?: ActivityItem) => void
-      clientHasQueueEntry: boolean
-      confirmRemove: () => Promise<void>
-    }
-
-    // Ensure failed tab contains queue item
-    vm.selectedTab = 'failed'
-    await new Promise((r) => setTimeout(r, 10))
-
-    const failedItems = vm.filteredQueue
-    const item = failedItems.find((i) => i.id === 'q2')
-
-    vm.removeFromQueue(item)
-    expect(vm.clientHasQueueEntry).toBe(true)
-
-    await vm.confirmRemove()
-    expect(removeFromQueueMock).toHaveBeenCalledWith('q2', 'qbittorrent')
-  }, 20000)
-
-  it('maps ImportPending to downloading and ImportBlocked to failed buckets', async () => {
-    vi.resetModules()
-
-    vi.doMock('@/services/signalr', () => ({
-      signalRService: {
-        connect: vi.fn(async () => undefined),
-        onQueueUpdate: vi.fn(() => () => undefined),
-        onFilesRemoved: vi.fn(() => () => undefined),
-        onToast: vi.fn(() => () => undefined),
-        onAudiobookUpdate: vi.fn(() => () => undefined),
-        onDownloadUpdate: vi.fn(() => () => undefined),
-        onDownloadsList: vi.fn(() => () => undefined),
-      },
-    }))
-
-    vi.doMock('@/services/api', () => ({
-      apiService: {
-        getQueue: async () => [],
-        getServiceHealth: async () => ({ version: '0.0.0' }),
-        getStartupConfig: async () => ({ authenticationRequired: false }),
-        getLibrary: async () => [],
-      },
-    }))
-
-    vi.doMock('@/stores/configuration', () => ({
-      useConfigurationStore: () => ({
-        applicationSettings: { showCompletedExternalDownloads: false },
-        loadApplicationSettings: vi.fn(async () => undefined),
-      }),
-    }))
-
-    vi.doMock('@/stores/downloads', () => ({
-      useDownloadsStore: () => ({
-        activeDownloads: [
-          {
-            id: 'd-importpending',
-            title: 'Import Pending',
-            status: 'ImportPending',
-            progress: 99,
-            totalSize: 1000,
-            downloadedSize: 990,
-            downloadClientId: 'qbittorrent',
-            startedAt: new Date().toISOString(),
-          },
-        ],
-        failedDownloads: [
-          {
-            id: 'd-importblocked',
-            title: 'Import Blocked',
-            status: 'ImportBlocked',
-            progress: 100,
-            totalSize: 1000,
-            downloadedSize: 1000,
-            downloadClientId: 'qbittorrent',
-            startedAt: new Date().toISOString(),
-          },
-        ],
-        completedDownloads: [],
-        loadDownloads: vi.fn(async () => undefined),
-      }),
-    }))
-
-    const { default: ActivityViewComponent } = await import('@/views/activity/ActivityView.vue')
-    const wrapper = mount(ActivityViewComponent, { global: { stubs: ['CustomSelect'] } })
-
-    await new Promise((r) => setTimeout(r, 10))
-
-    const vm = wrapper.vm as unknown as {
-      filterTabs: FilterTab[]
-      selectedTab: string
-      filteredQueue: ActivityItem[]
-    }
-
-    const downloadingTab = vm.filterTabs.find((t) => t.value === 'downloading')
-    const failedTab = vm.filterTabs.find((t) => t.value === 'failed')
-
-    expect(downloadingTab?.count).toBe(1)
-    expect(failedTab?.count).toBe(1)
-
-    vm.selectedTab = 'downloading'
-    await new Promise((r) => setTimeout(r, 10))
-    expect(vm.filteredQueue.some((item) => item.id === 'd-importpending')).toBe(true)
-
-    vm.selectedTab = 'failed'
-    await new Promise((r) => setTimeout(r, 10))
-    expect(vm.filteredQueue.some((item) => item.id === 'd-importblocked')).toBe(true)
-  }, 20000)
+    expect(vm.allActivityItems.find((item) => item.id === 'd-importpending')?.status).toBe(
+      'importpending',
+    )
+    expect(vm.allActivityItems.find((item) => item.id === 'd-importblocked')?.status).toBe(
+      'importblocked',
+    )
+  })
 
   it('shows unavailable client health even when no queue items are returned', async () => {
-    vi.resetModules()
+    mockSignalR()
+    mockApi({
+      getQueue: vi.fn(async () => ({
+        items: [],
+        clients: [
+          {
+            clientId: 'qb-1',
+            clientName: 'qBittorrent',
+            clientType: 'qbittorrent',
+            snapshotState: 'unavailable',
+            isStaleSnapshot: false,
+            isUnavailable: true,
+            snapshotFailureReason: 'timeout',
+            itemCount: 0,
+          },
+        ],
+        generatedAt: new Date().toISOString(),
+        hasStaleData: false,
+        hasUnavailableClients: true,
+      })),
+    })
+    mockConfigurationStore(false)
+    mockLibraryStore()
+    mockDownloadsStore()
 
-    vi.doMock('@/services/signalr', () => ({
-      signalRService: {
-        connect: vi.fn(async () => undefined),
-        onQueueUpdate: vi.fn(() => () => undefined),
-        onFilesRemoved: vi.fn(() => () => undefined),
-        onToast: vi.fn(() => () => undefined),
-        onAudiobookUpdate: vi.fn(() => () => undefined),
-        onDownloadUpdate: vi.fn(() => () => undefined),
-        onDownloadsList: vi.fn(() => () => undefined),
-      },
-    }))
+    const wrapper = await mountActivityView()
+    const vm = wrapper.vm as unknown as ActivityViewVm
 
-    vi.doMock('@/services/api', () => ({
-      apiService: {
-        getQueue: async () => ({
-          items: [],
-          clients: [
-            {
-              clientId: 'qb-1',
-              clientName: 'qBittorrent',
-              clientType: 'qbittorrent',
-              snapshotState: 'unavailable',
-              isStaleSnapshot: false,
-              isUnavailable: true,
-              snapshotFailureReason: 'timeout',
-              itemCount: 0,
-            },
-          ],
-          generatedAt: new Date().toISOString(),
-          hasStaleData: false,
-          hasUnavailableClients: true,
-        }),
-        getServiceHealth: async () => ({ version: '0.0.0' }),
-        getStartupConfig: async () => ({ authenticationRequired: false }),
-        getLibrary: async () => [],
-      },
-    }))
-
-    vi.doMock('@/stores/configuration', () => ({
-      useConfigurationStore: () => ({
-        applicationSettings: { showCompletedExternalDownloads: false },
-        loadApplicationSettings: vi.fn(async () => undefined),
-      }),
-    }))
-
-    vi.doMock('@/stores/downloads', () => ({
-      useDownloadsStore: () => ({
-        activeDownloads: [],
-        failedDownloads: [],
-        completedDownloads: [],
-        loadDownloads: vi.fn(async () => undefined),
-      }),
-    }))
-
-    const { default: ActivityViewComponent } = await import('@/views/activity/ActivityView.vue')
-    const wrapper = mount(ActivityViewComponent, { global: { stubs: ['CustomSelect'] } })
-
-    await new Promise((r) => setTimeout(r, 10))
-
+    expect(vm.queueHealthClients).toHaveLength(1)
+    expect(vm.queueHealthClients[0]?.name).toBe('qBittorrent')
     expect(wrapper.text()).toContain('Some queue data is unavailable')
     expect(wrapper.text()).toContain('qBittorrent unavailable after a timeout')
-  }, 20000)
+  })
 
   it('prefers the queue snapshot over an external active download with the same tracked id', async () => {
-    vi.resetModules()
-
-    vi.doMock('@/services/signalr', () => ({
-      signalRService: {
-        connect: vi.fn(async () => undefined),
-        onQueueUpdate: vi.fn(() => () => undefined),
-        onFilesRemoved: vi.fn(() => () => undefined),
-        onToast: vi.fn(() => () => undefined),
-        onAudiobookUpdate: vi.fn(() => () => undefined),
-        onDownloadUpdate: vi.fn(() => () => undefined),
-        onDownloadsList: vi.fn(() => () => undefined),
-      },
-    }))
-
-    vi.doMock('@/services/api', () => ({
-      apiService: {
-        getQueue: async () => ({
-          items: [
-            {
-              id: 'tracked-artemis',
-              title: 'Artemis',
-              status: 'completed',
-              progress: 100,
-              size: 489100000,
-              downloaded: 489100000,
-              downloadSpeed: 77300,
-              quality: 'Unknown',
-              downloadClient: 'QBIT',
-              downloadClientId: 'qb-1',
-              downloadClientType: 'qbittorrent',
-              addedAt: new Date().toISOString(),
-              canPause: false,
-              canRemove: true,
-            },
-          ],
-          clients: [],
-          generatedAt: new Date().toISOString(),
-          hasStaleData: false,
-          hasUnavailableClients: false,
-        }),
-        getServiceHealth: async () => ({ version: '0.0.0' }),
-        getStartupConfig: async () => ({ authenticationRequired: false }),
-        getLibrary: async () => [],
-      },
-    }))
-
-    vi.doMock('@/stores/configuration', () => ({
-      useConfigurationStore: () => ({
-        applicationSettings: { showCompletedExternalDownloads: false },
-        loadApplicationSettings: vi.fn(async () => undefined),
-      }),
-    }))
-
-    vi.doMock('@/stores/downloads', () => ({
-      useDownloadsStore: () => ({
-        activeDownloads: [
+    mockSignalR()
+    mockApi({
+      getQueue: vi.fn(async () => ({
+        items: [
           {
             id: 'tracked-artemis',
             title: 'Artemis',
-            status: 'Downloading',
+            status: 'completed',
             progress: 100,
-            totalSize: 489100000,
-            downloadedSize: 489100000,
+            size: 489100000,
+            downloaded: 489100000,
+            downloadSpeed: 77300,
+            quality: 'Unknown',
+            downloadClient: 'QBIT',
             downloadClientId: 'qb-1',
-            startedAt: new Date().toISOString(),
+            downloadClientType: 'qbittorrent',
+            addedAt: new Date().toISOString(),
+            canPause: false,
+            canRemove: true,
           },
         ],
-        failedDownloads: [],
-        completedDownloads: [],
-        loadDownloads: vi.fn(async () => undefined),
-      }),
-    }))
+        clients: [],
+        generatedAt: new Date().toISOString(),
+        hasStaleData: false,
+        hasUnavailableClients: false,
+      })),
+    })
+    mockConfigurationStore(true)
+    mockLibraryStore()
+    mockDownloadsStore({
+      activeDownloads: [
+        {
+          id: 'tracked-artemis',
+          title: 'Artemis',
+          status: 'Downloading',
+          progress: 100,
+          totalSize: 489100000,
+          downloadedSize: 489100000,
+          downloadClientId: 'qb-1',
+          startedAt: new Date().toISOString(),
+        },
+      ],
+    })
 
-    const { default: ActivityViewComponent } = await import('@/views/activity/ActivityView.vue')
-    const wrapper = mount(ActivityViewComponent, { global: { stubs: ['CustomSelect'] } })
+    const wrapper = await mountActivityView()
+    const vm = wrapper.vm as unknown as ActivityViewVm
 
-    await new Promise((r) => setTimeout(r, 10))
-
-    const vm = wrapper.vm as unknown as {
-      filterTabs: FilterTab[]
-      selectedTab: string
-      filteredQueue: ActivityItem[]
-    }
-
-    const downloadingTab = vm.filterTabs.find((t) => t.value === 'downloading')
-    const completedTab = vm.filterTabs.find((t) => t.value === 'completed')
-
-    expect(downloadingTab?.count).toBe(0)
-    expect(completedTab?.count).toBe(1)
-
-    vm.selectedTab = 'completed'
-    await new Promise((r) => setTimeout(r, 10))
-
-    expect(vm.filteredQueue).toHaveLength(1)
-    expect(vm.filteredQueue[0]?.id).toBe('tracked-artemis')
-    expect(vm.filteredQueue[0]?.title).toBe('Artemis')
-  }, 20000)
+    expect(vm.allActivityItems).toHaveLength(1)
+    expect(vm.allActivityItems[0]?.id).toBe('tracked-artemis')
+    expect(vm.allActivityItems[0]?.status).toBe('completed')
+    expect(vm.allActivityItems[0]?.title).toBe('Artemis')
+  })
 })

--- a/fe/src/__tests__/CollectionView.spec.ts
+++ b/fe/src/__tests__/CollectionView.spec.ts
@@ -966,7 +966,7 @@ describe('CollectionView', () => {
 
     expect(mockGetAuthorCatalog).toHaveBeenCalledWith('Andy Weir', 'uk', false)
     expect(mockGetAuthorMonitoringStatus).toHaveBeenCalledWith('Andy Weir', 'uk', 'german')
-    expect(wrapper.find('.author-monitoring-label').text()).toContain('United Kingdom (UK)')
+    expect(wrapper.find('.author-hero-meta').text()).toContain('United Kingdom (UK) / German')
 
     const monitorButton = wrapper.find('.author-monitor-btn')
     expect(monitorButton.text()).toContain('Monitor Author')
@@ -1049,7 +1049,7 @@ describe('CollectionView', () => {
 
     expect(mockGetSeriesCatalog).toHaveBeenCalledWith('Mistborn', 'uk', false)
     expect(mockGetSeriesMonitoringStatus).toHaveBeenCalledWith('Mistborn', 'uk', 'german')
-    expect(wrapper.find('.author-monitoring-label').text()).toContain('United Kingdom (UK)')
+    expect(wrapper.find('.author-hero-meta').text()).toContain('United Kingdom (UK) / German')
 
     const monitorButton = wrapper.find('.author-monitor-btn')
     expect(monitorButton.text()).toContain('Monitor Series')

--- a/fe/src/__tests__/DownloadSettingsSection.spec.ts
+++ b/fe/src/__tests__/DownloadSettingsSection.spec.ts
@@ -9,32 +9,48 @@ describe('DownloadSettingsSection', () => {
   it('emits update:settings when numerical inputs change', async () => {
     const { default: DownloadSettingsSection } = await import('@/components/settings/DownloadSettingsSection.vue')
     const wrapper = mount(DownloadSettingsSection, {
-      props: { settings: { maxConcurrentDownloads: 2, pollingIntervalSeconds: 30, downloadCompletionStabilitySeconds: 5, missingSourceRetryInitialDelaySeconds: 2, missingSourceMaxRetries: 3 } },
+      props: {
+        settings: {
+          maxConcurrentDownloads: 2,
+          unmatchedScanConcurrency: 2,
+          pollingIntervalSeconds: 30,
+          downloadCompletionStabilitySeconds: 5,
+          missingSourceRetryInitialDelaySeconds: 2,
+          missingSourceMaxRetries: 3,
+        },
+      },
     })
 
     const inputs = wrapper.findAll('input[type="number"]')
+    expect(inputs).toHaveLength(6)
+
     // Max concurrent
     await inputs[0].setValue('4')
     let last = wrapper.emitted()['update:settings']![wrapper.emitted()['update:settings']!.length - 1][0]
     expect(last.maxConcurrentDownloads).toBe(4)
 
+    // Unmatched scan concurrency
+    await inputs[1].setValue('3')
+    last = wrapper.emitted()['update:settings']![wrapper.emitted()['update:settings']!.length - 1][0]
+    expect(last.unmatchedScanConcurrency).toBe(3)
+
     // Polling interval
-    await inputs[1].setValue('60')
+    await inputs[2].setValue('60')
     last = wrapper.emitted()['update:settings']![wrapper.emitted()['update:settings']!.length - 1][0]
     expect(last.pollingIntervalSeconds).toBe(60)
 
     // Stability
-    await inputs[2].setValue('10')
+    await inputs[3].setValue('10')
     last = wrapper.emitted()['update:settings']![wrapper.emitted()['update:settings']!.length - 1][0]
     expect(last.downloadCompletionStabilitySeconds).toBe(10)
 
     // Missing-source delay
-    await inputs[3].setValue('3')
+    await inputs[4].setValue('3')
     last = wrapper.emitted()['update:settings']![wrapper.emitted()['update:settings']!.length - 1][0]
     expect(last.missingSourceRetryInitialDelaySeconds).toBe(3)
 
     // Missing-source retries
-    await inputs[4].setValue('5')
+    await inputs[5].setValue('5')
     last = wrapper.emitted()['update:settings']![wrapper.emitted()['update:settings']!.length - 1][0]
     expect(last.missingSourceMaxRetries).toBe(5)
   })

--- a/fe/src/__tests__/WantedView.spec.ts
+++ b/fe/src/__tests__/WantedView.spec.ts
@@ -145,8 +145,8 @@ describe('WantedView image recache behavior', () => {
     const wrapper = mount(WantedView, { global: { plugins: [pinia] } })
     await new Promise((resolve) => setTimeout(resolve, 10))
 
-    expect(wrapper.find('.wanted-list-container').classes()).toContain('is-static')
-    expect(wrapper.find('.wanted-list.is-static').exists()).toBe(true)
-    expect(wrapper.findAll('.wanted-item')).toHaveLength(30)
+    expect(wrapper.find('.wanted-grid-container').classes()).toContain('is-static')
+    expect(wrapper.find('.wanted-body.is-static').exists()).toBe(true)
+    expect(wrapper.findAll('.wanted-row')).toHaveLength(30)
   })
 })

--- a/fe/src/__tests__/useAdvancedSearch.spec.ts
+++ b/fe/src/__tests__/useAdvancedSearch.spec.ts
@@ -38,7 +38,6 @@ describe('useAdvancedSearch', () => {
         isbn: '',
         series: '',
         asin: '',
-        language: '',
       })
     })
 
@@ -51,7 +50,6 @@ describe('useAdvancedSearch', () => {
           isbn: '',
           series: '',
           asin: 'B123',
-          language: 'english',
         },
       }
       localStorageMock['listenarr.addnew.advanced'] = JSON.stringify(savedState)
@@ -79,7 +77,6 @@ describe('useAdvancedSearch', () => {
           isbn: '',
           series: '',
           asin: '',
-          language: '',
         },
       }
       localStorageMock['listenarr.addnew.advanced'] = JSON.stringify(savedState)
@@ -244,7 +241,6 @@ describe('useAdvancedSearch', () => {
         isbn: '',
         series: '',
         asin: '',
-        language: '',
       })
     })
 
@@ -277,7 +273,6 @@ describe('useAdvancedSearch', () => {
         isbn: '',
         series: '',
         asin: '',
-        language: '',
       })
     })
 


### PR DESCRIPTION
This PR closes a number of longer-standing bugs and feature requests, and also includes a broader refresh of download queue handling, automatic import reliability, and the Activity/Wanted UI surfaces.

## Added

- Expanded `Add New` language filters with support for Swedish, Norwegian, Danish, Finnish, Dutch, Portuguese, Japanese, Chinese, Czech, Turkish, Hindi, Korean, Arabic, Greek, and Hebrew. (Closes #432, Closes #205)
- Added matching ISO 639 language parsing for MAM search results.
- Added Docker `PUID`, `PGID`, and `UMASK` support so containers can run as a custom user/group, with automatic ownership correction for existing config files. (Closes #309)
- Added `atcr.io` as a published container registry alongside Docker Hub and GHCR for nightly, canary, and release workflows. (Closes #268)
- Added a normalized queue snapshot model with per-client health/staleness metadata so the Activity view and queue updates can use a shared, richer payload.
- Added `audiobookId` propagation to queue items so Activity and Wanted rows can link directly back to the matching audiobook.
- Added exact client-reported source file tracking for automatic imports so multi-file downloads can be scoped to the files that actually belong to the download.

## Fixed

- Fixed ASIN searches in the `Add New` view returning zero results by restoring missing metadata fields needed for language-filtered results. (Closes #434)
- Fixed search failures for titles and authors containing diacritics or special characters by retrying with normalized text and using diacritic-insensitive matching. (Closes #430)
- Fixed Audible catalog search returning irrelevant trending or popular results by correcting request parameters and headers.
- Fixed Add New advanced title searches returning blank or irrelevant results by stripping pasted structured prefixes like `AUTHOR:`, `TITLE:`, `ISBN:`, and `ASIN:` before query composition, and improving title-only Audible fallback behavior.
- Fixed series-only advanced search failures by improving ASIN resolution, result mapping, language filtering, fallback behavior, and empty-result handling.
- Fixed NZBGet XML-RPC authentication by switching to an explicit Basic Auth header instead of embedded URL credentials.
- Fixed manual import so `hardlink/copy` mode now correctly hardlinks primary and companion files when possible.
- Fixed Library Import mode selection so non-move settings no longer incorrectly fall back to `move`.
- Fixed MAM torrents stalling in qBittorrent due to missing tracker URLs by preserving auth cookies, injecting trackers, and repairing announce-list parsing. (Closes #429)
- Fixed MAM indexer saves so redaction no longer wipes the stored MAM ID or breaks frontend JSON handling.
- Fixed phantom duplicate-download blocking by ignoring stale completed records from disabled or removed clients and returning `409 Conflict` when a download is skipped.
- Fixed SABnzbd completed download actions so `Remove` and `Remove and Delete` now use the correct `nzo_id` instead of Listenarr’s internal GUID, allowing history cleanup and source-directory removal to work properly. (Closes #300)
- Fixed SABnzbd completed jobs disappearing from queue/import tracking by reading completed items from history as well as the active queue.
- Fixed automatic import pulling unrelated files from the download directory by scoping directory imports to the download client’s reported source files.
- Fixed automatic import promoting non-audio companions like `.jpg` into audiobook file records, while still allowing valid companion files like `.txt` to import when not blacklisted.
- Fixed Docker startup when only `PUID` is set by defaulting `PGID` safely and avoiding root-group collisions.

## Changed

- Reworked both Activity and Wanted around denser table-based views for easier scanning of statuses, queue context, and actions across larger result sets.
- Updated the Activity queue to use normalized snapshot payloads with per-client stale/unavailable state, snapshot age, and stronger reconciliation to reduce duplicate or stale rows.
- Consolidated CI secrets to organization-level secret management.
- Updated Docker documentation/examples to use `PUID`, `PGID`, and `UMASK` instead of hardcoded `user:` settings.

## Removed

- Removed the old hardcoded Docker `user:` approach from the documented container setup in favor of the new env-var-driven runtime user mapping.
