### PR TITLE
Audiobook metadata editing and library organization

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -274,7 +274,6 @@ jobs:
           echo "Resolved version: ${{ steps.resolve-version.outputs.VERSION }}"
 
       - name: Login to Docker Hub
-        if: github.run_attempt == 1
         uses: docker/login-action@v2
         with:
           registry: docker.io
@@ -282,7 +281,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        if: github.run_attempt == 1
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -290,7 +288,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to ATCR
-        if: github.run_attempt == 1
         uses: docker/login-action@v2
         with:
           registry: atcr.io
@@ -307,7 +304,6 @@ jobs:
           echo "ATCR_IMAGE=atcr.io/therobbiedavis.com/listenarr" >> $GITHUB_OUTPUT
 
       - name: Find triggering Pull Request
-        if: github.run_attempt == 1
         id: find_triggering_pr
         run: |
           # Find merged PRs associated with this commit, excluding version bump PRs
@@ -379,7 +375,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sanitize PR body and create release notes
-        if: github.run_attempt == 1
         id: sanitize_pr_body
         run: |
           # Sanitize PR body - remove potential malicious content, limit length
@@ -438,7 +433,6 @@ jobs:
           PR_NUMBER: ${{ steps.find_triggering_pr.outputs.PR_NUMBER }}
 
       - name: Create GitHub Pre-Release
-        if: github.run_attempt == 1
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.resolve-version.outputs.VERSION }}
@@ -450,11 +444,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        if: github.run_attempt == 1
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        if: github.run_attempt == 1
         uses: docker/setup-buildx-action@v2
 
       - name: Publish API for runtime image
@@ -502,7 +494,6 @@ jobs:
           path: listenarr.api/publish
 
       - name: Build and push API image (canary + sha)
-        if: github.run_attempt == 1
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -28,14 +28,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Refresh to current canary head on rerun
-        if: github.run_attempt != 1
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: canary
-          clean: true
-
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v3
         with:
@@ -46,41 +38,82 @@ jobs:
         with:
           node-version: 20
 
-      - name: Resolve version
+      - name: Resolve target version
         id: resolve-version
         run: |
           set -euo pipefail
           CSProj=${{ env.API_PROJECT }}
 
-          # Read <Version> from csproj, then fall back to <AssemblyVersion>
-          VERSION=$(sed -n "s:.*<Version>\(.*\)</Version>.*:\1:p" "$CSProj" 2>/dev/null || true)
-          if [ -z "${VERSION}" ]; then
-            VERSION=$(sed -n "s:.*<AssemblyVersion>\(.*\)</AssemblyVersion>.*:\1:p" "$CSProj" 2>/dev/null || true)
+          SOURCE_VERSION=$(sed -n "s:.*<Version>\(.*\)</Version>.*:\1:p" "$CSProj" 2>/dev/null || true)
+          if [ -z "${SOURCE_VERSION}" ]; then
+            SOURCE_VERSION=$(sed -n "s:.*<AssemblyVersion>\(.*\)</AssemblyVersion>.*:\1:p" "$CSProj" 2>/dev/null || true)
           fi
-          if [ -z "${VERSION}" ]; then
-            VERSION=$(node -p "require('./fe/package.json').version" 2>/dev/null || echo "0.0.0")
-          fi
-
-          echo "Found base version: ${VERSION}"
-
-          if [ "${{ github.run_attempt }}" != "1" ]; then
-            RESOLVED_VERSION="${VERSION}"
-            echo "Rerun detected. Using current canary version without bump: ${RESOLVED_VERSION}"
-          else
-            IFS='.' read -r MAJOR MINOR PATCH <<< "${VERSION}"
-            PATCH=${PATCH:-0}
-            NEWPATCH=$((PATCH + 1))
-            RESOLVED_VERSION="${MAJOR}.${MINOR}.${NEWPATCH}"
-            echo "Bumped canary version: ${RESOLVED_VERSION}"
+          if [ -z "${SOURCE_VERSION}" ]; then
+            SOURCE_VERSION=$(node -p "require('./fe/package.json').version" 2>/dev/null || echo "0.0.0")
           fi
 
-          echo "VERSION=${RESOLVED_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Found source version from triggering commit: ${SOURCE_VERSION}"
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "${SOURCE_VERSION}"
+          PATCH=${PATCH:-0}
+          TARGET_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+
+          echo "Target canary version: ${TARGET_VERSION}"
+          echo "SOURCE_VERSION=${SOURCE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "VERSION=${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Inspect current canary version
+        id: inspect_target
+        run: |
+          set -euo pipefail
+          git fetch origin canary --depth=1
+
+          BRANCH_XML="$(git show origin/canary:${{ env.API_PROJECT }} 2>/dev/null || true)"
+          BRANCH_VERSION=$(printf '%s\n' "$BRANCH_XML" | sed -n "s:.*<Version>\(.*\)</Version>.*:\1:p" | head -n1)
+          if [ -z "${BRANCH_VERSION}" ]; then
+            BRANCH_VERSION=$(printf '%s\n' "$BRANCH_XML" | sed -n "s:.*<AssemblyVersion>\(.*\)</AssemblyVersion>.*:\1:p" | head -n1)
+          fi
+
+          echo "Current canary version: ${BRANCH_VERSION:-<unknown>}"
+          echo "BRANCH_VERSION=${BRANCH_VERSION}" >> "$GITHUB_OUTPUT"
+
+          STATE=$(python3 - "${BRANCH_VERSION}" "${{ steps.resolve-version.outputs.VERSION }}" <<'PY'
+          import sys
+
+          branch = sys.argv[1].strip()
+          target = sys.argv[2].strip()
+
+          def parse(v: str):
+              return tuple(int(x) for x in v.split("."))
+
+          if not branch:
+              print("pending")
+          else:
+              b = parse(branch)
+              t = parse(target)
+              if b == t:
+                  print("applied")
+              elif b > t:
+                  print("superseded")
+              else:
+                  print("pending")
+          PY
+          )
+
+          echo "bump_state=${STATE}" >> "$GITHUB_OUTPUT"
+          echo "Computed bump state: ${STATE}"
+
+      - name: Abort obsolete run
+        if: steps.inspect_target.outputs.bump_state == 'superseded'
+        run: |
+          echo "::error::Current canary version (${{ steps.inspect_target.outputs.BRANCH_VERSION }}) is newer than target version (${{ steps.resolve-version.outputs.VERSION }}). This run is obsolete and will not publish stale artifacts."
+          exit 1
 
       - name: Restore .NET
         run: dotnet restore listenarr.slnx
 
-      - name: Persist bumped version to csproj (first attempt only)
-        if: github.run_attempt == 1 && steps.resolve-version.outputs.VERSION != ''
+      - name: Persist bumped version to csproj
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.resolve-version.outputs.VERSION != ''
         env:
           NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
         run: |
@@ -95,7 +128,6 @@ jobs:
           tree = ET.parse(path)
           root = tree.getroot()
 
-          # Update Version
           found_version = False
           for elem in root.findall('.//Version'):
               elem.text = new
@@ -107,7 +139,6 @@ jobs:
                   pg = ET.SubElement(root, 'PropertyGroup')
               ET.SubElement(pg, 'Version').text = new
 
-          # Update AssemblyVersion
           found_assembly = False
           for elem in root.findall('.//AssemblyVersion'):
               elem.text = new
@@ -125,14 +156,14 @@ jobs:
           python3 update_version.py
 
       - name: Sync frontend and package metadata to bumped version
-        if: github.run_attempt == 1 && steps.resolve-version.outputs.VERSION != ''
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.resolve-version.outputs.VERSION != ''
         env:
           NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
         run: node scripts/sync-fe-version-from-csproj.mjs
 
       - name: Check for tracked version changes
         id: version_changes
-        if: github.run_attempt == 1
+        if: steps.inspect_target.outputs.bump_state == 'pending'
         run: |
           set -euo pipefail
           if git diff --quiet -- \
@@ -150,7 +181,7 @@ jobs:
 
       - name: Create Pull Request for version bump
         id: create_pr
-        if: github.run_attempt == 1 && steps.version_changes.outputs.has_changes == 'true'
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.version_changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GH_PAT }}
@@ -163,8 +194,14 @@ jobs:
             This PR bumps the application version to ${{ steps.resolve-version.outputs.VERSION }}.
             The change was produced automatically by the CI canary workflow.
 
+      - name: Ensure version bump PR exists when required
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.create_pr.outputs.pull-request-number == ''
+        run: |
+          echo "::error::A canary version bump was required, but no pull request was created or found."
+          exit 1
+
       - name: Label version bump PR
-        if: github.run_attempt == 1 && steps.create_pr.outputs.pull-request-number != ''
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.create_pr.outputs.pull-request-number != ''
         continue-on-error: true
         uses: actions/github-script@v6
         with:
@@ -199,7 +236,7 @@ jobs:
             }
 
       - name: Merge version bump PR (skip CI)
-        if: github.run_attempt == 1 && steps.create_pr.outputs.pull-request-number != ''
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.create_pr.outputs.pull-request-number != ''
         uses: actions/github-script@v6
         env:
           PR_NUMBER: ${{ steps.create_pr.outputs['pull-request-number'] }}
@@ -219,7 +256,7 @@ jobs:
             });
 
       - name: Refresh workspace to current canary version
-        if: github.run_attempt != 1 || steps.create_pr.outputs.pull-request-number != ''
+        if: steps.inspect_target.outputs.bump_state == 'applied' || steps.create_pr.outputs.pull-request-number != ''
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -227,7 +264,7 @@ jobs:
           clean: true
 
       - name: Verify synced workspace version
-        if: steps.resolve-version.outputs.VERSION != ''
+        if: steps.inspect_target.outputs.bump_state == 'applied' || steps.create_pr.outputs.pull-request-number != ''
         env:
           NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
         run: |
@@ -297,17 +334,13 @@ jobs:
       - name: Set image name
         id: set-tags
         run: |
-          # Use repository owner as namespace for Docker Hub
           echo "DOCKER_IMAGE=docker.io/therobbiedavis/listenarr" >> $GITHUB_OUTPUT
-          # Publish GHCR images under the same owner namespace
           echo "GHCR_IMAGE=ghcr.io/listenarrs/listenarr" >> $GITHUB_OUTPUT
           echo "ATCR_IMAGE=atcr.io/therobbiedavis.com/listenarr" >> $GITHUB_OUTPUT
 
       - name: Find triggering Pull Request
         id: find_triggering_pr
         run: |
-          # Find merged PRs associated with this commit, excluding version bump PRs
-          # Use a simpler approach: get recent merged PRs to canary and find the right one
           PR_DATA=$(gh api graphql -f query='
             query($owner: String!, $repo: String!) {
               repository(owner: $owner, name: $repo) {
@@ -332,7 +365,6 @@ jobs:
               }
             }' -f owner='${{ github.repository_owner }}' -f repo='${{ github.event.repository.name }}')
 
-          # Filter out version bump PRs and find the first non-version-bump PR
           FILTERED_PR=$(echo "$PR_DATA" | jq -r '
             [.data.repository.pullRequests.edges[] |
             select(
@@ -343,11 +375,9 @@ jobs:
             {number, title, body, baseRefName}][0] // null
           ')
 
-          # Debug: Show what PRs we found
           echo "Recent PRs found:"
           echo "$PR_DATA" | jq -r '.data.repository.pullRequests.edges[:5][] | "PR #\(.node.number): \(.node.title)"'
 
-          # Extract PR details from the filtered result
           if [ "$FILTERED_PR" != "" ] && [ "$FILTERED_PR" != "null" ]; then
             PR_NUMBER=$(echo "$FILTERED_PR" | jq -r '.number // ""')
             PR_TITLE=$(echo "$FILTERED_PR" | jq -r '.title // ""')
@@ -367,7 +397,6 @@ jobs:
           echo "PR_TITLE=$PR_TITLE" >> $GITHUB_OUTPUT
           echo "PR_BASE_REF=$PR_BASE_REF" >> $GITHUB_OUTPUT
 
-          # Store raw PR body for sanitization
           echo "PR_BODY_RAW<<EOF_PR_BODY" >> $GITHUB_OUTPUT
           echo "$PR_BODY_RAW" >> $GITHUB_OUTPUT
           echo "EOF_PR_BODY" >> $GITHUB_OUTPUT
@@ -377,39 +406,27 @@ jobs:
       - name: Sanitize PR body and create release notes
         id: sanitize_pr_body
         run: |
-          # Sanitize PR body - remove potential malicious content, limit length
           python3 << 'PYTHON_SCRIPT'
           import os
           import re
           import html
 
-          # Get the raw PR body
           pr_body_raw = os.environ.get('PR_BODY_RAW', '')
 
-          # Basic sanitization
-          # 1. HTML escape to prevent injection
           sanitized = html.escape(pr_body_raw)
-
-          # 2. Remove script tags and other potentially dangerous content
           sanitized = re.sub(r'<script[^>]*>.*?</script>', '', sanitized, flags=re.IGNORECASE | re.DOTALL)
           sanitized = re.sub(r'<iframe[^>]*>.*?</iframe>', '', sanitized, flags=re.IGNORECASE | re.DOTALL)
           sanitized = re.sub(r'javascript:', '', sanitized, flags=re.IGNORECASE)
 
-          # 3. Limit length to prevent overly long descriptions (max 2000 chars)
           if len(sanitized) > 2000:
               sanitized = sanitized[:1997] + '...'
 
-          # 4. Clean up excessive whitespace
           sanitized = re.sub(r'\n\s*\n\s*\n', '\n\n', sanitized)
           sanitized = sanitized.strip()
 
-          # If empty after sanitization, provide a default
           if not sanitized:
               sanitized = "No description provided."
 
-          print(f"Sanitized PR body (length: {len(sanitized)} chars)")
-
-          # Create the full body for the release
           full_body = f"""{sanitized}
 
           ---
@@ -420,11 +437,9 @@ jobs:
           - Commit: {os.environ.get('GITHUB_SHA', 'unknown')}
           - Original PR: #{os.environ.get('PR_NUMBER', 'unknown')}"""
 
-          # Output the sanitized content
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
               f.write(f"SANITIZED_PR_BODY<<EOF_SANITIZED\n{sanitized}\nEOF_SANITIZED\n")
               f.write(f"FULL_RELEASE_BODY<<EOF_FULL\n{full_body}\nEOF_FULL\n")
-
           PYTHON_SCRIPT
         env:
           PR_BODY_RAW: ${{ steps.find_triggering_pr.outputs.PR_BODY_RAW }}
@@ -452,7 +467,6 @@ jobs:
       - name: Publish API for runtime image
         run: |
           dotnet publish listenarr.api/Listenarr.Api.csproj -c Release -o listenarr.api/publish
-        # Ensures Listenarr.Api.dll is at listenarr.api/publish/ for Dockerfile.runtime
 
       - name: Show publish contents (sanity check)
         run: |
@@ -515,7 +529,7 @@ jobs:
         if: github.run_attempt == 1 && github.repository_owner == 'listenarrs'
         with:
           severity: info
-          description: v${{steps.resolve-version.outputs.VERSION}} - ${{ steps.find_triggering_pr.outputs.PR_TITLE }}
+          description: v${{ steps.resolve-version.outputs.VERSION }} - ${{ steps.find_triggering_pr.outputs.PR_TITLE }}
           details: '${{ steps.sanitize_pr_body.outputs.SANITIZED_PR_BODY }}'
           text: A new canary build has been released for docker.
           webhookUrl: ${{ secrets.LISTENARR_DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,5 +1,9 @@
 name: Canary — build executables & Docker (canary)
 
+concurrency:
+  group: canary-build-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write
@@ -24,6 +28,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Refresh to current canary head on rerun
+        if: github.run_attempt != 1
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: canary
+          clean: true
+
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v3
         with:
@@ -34,11 +46,12 @@ jobs:
         with:
           node-version: 20
 
-      - name: Resolve and bump version (patch)
+      - name: Resolve version
         id: resolve-version
         run: |
           set -euo pipefail
           CSProj=${{ env.API_PROJECT }}
+
           # Read <Version> from csproj, then fall back to <AssemblyVersion>
           VERSION=$(sed -n "s:.*<Version>\(.*\)</Version>.*:\1:p" "$CSProj" 2>/dev/null || true)
           if [ -z "${VERSION}" ]; then
@@ -47,19 +60,27 @@ jobs:
           if [ -z "${VERSION}" ]; then
             VERSION=$(node -p "require('./fe/package.json').version" 2>/dev/null || echo "0.0.0")
           fi
+
           echo "Found base version: ${VERSION}"
-          IFS='.' read -r MAJOR MINOR PATCH <<< "${VERSION}"
-          PATCH=${PATCH:-0}
-          NEWPATCH=$((PATCH + 1))
-          NEWVERSION="${MAJOR}.${MINOR}.${NEWPATCH}"
-          echo "Bumped canary version: ${NEWVERSION}"
-          echo "VERSION=${NEWVERSION}" >> $GITHUB_OUTPUT
+
+          if [ "${{ github.run_attempt }}" != "1" ]; then
+            RESOLVED_VERSION="${VERSION}"
+            echo "Rerun detected. Using current canary version without bump: ${RESOLVED_VERSION}"
+          else
+            IFS='.' read -r MAJOR MINOR PATCH <<< "${VERSION}"
+            PATCH=${PATCH:-0}
+            NEWPATCH=$((PATCH + 1))
+            RESOLVED_VERSION="${MAJOR}.${MINOR}.${NEWPATCH}"
+            echo "Bumped canary version: ${RESOLVED_VERSION}"
+          fi
+
+          echo "VERSION=${RESOLVED_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Restore .NET
         run: dotnet restore listenarr.slnx
 
-      - name: Persist bumped version to csproj (for build)
-        if: steps.resolve-version.outputs.VERSION != ''
+      - name: Persist bumped version to csproj (first attempt only)
+        if: github.run_attempt == 1 && steps.resolve-version.outputs.VERSION != ''
         env:
           NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
         run: |
@@ -68,10 +89,12 @@ jobs:
           cat > update_version.py <<'PY'
           import os
           import xml.etree.ElementTree as ET
+
           path = 'listenarr.api/Listenarr.Api.csproj'
           new = os.environ['NEW_VERSION']
           tree = ET.parse(path)
           root = tree.getroot()
+
           # Update Version
           found_version = False
           for elem in root.findall('.//Version'):
@@ -83,6 +106,7 @@ jobs:
               if pg is None:
                   pg = ET.SubElement(root, 'PropertyGroup')
               ET.SubElement(pg, 'Version').text = new
+
           # Update AssemblyVersion
           found_assembly = False
           for elem in root.findall('.//AssemblyVersion'):
@@ -94,32 +118,53 @@ jobs:
               if pg is None:
                   pg = ET.SubElement(root, 'PropertyGroup')
               ET.SubElement(pg, 'AssemblyVersion').text = new
+
           tree.write(path, encoding='utf-8', xml_declaration=True)
           print('Wrote new version and assembly version to csproj')
           PY
           python3 update_version.py
 
       - name: Sync frontend and package metadata to bumped version
-        if: steps.resolve-version.outputs.VERSION != ''
+        if: github.run_attempt == 1 && steps.resolve-version.outputs.VERSION != ''
         env:
           NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
         run: node scripts/sync-fe-version-from-csproj.mjs
 
+      - name: Check for tracked version changes
+        id: version_changes
+        if: github.run_attempt == 1
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- \
+            listenarr.api/Listenarr.Api.csproj \
+            package.json \
+            package-lock.json \
+            fe/package.json \
+            fe/package-lock.json; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No tracked version changes detected."
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Tracked version changes detected."
+          fi
+
       - name: Create Pull Request for version bump
         id: create_pr
+        if: github.run_attempt == 1 && steps.version_changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GH_PAT }}
           commit-message: "[skip ci] Bump version to ${{ steps.resolve-version.outputs.VERSION }}"
           branch: "ci/canary-version-bump-${{ steps.resolve-version.outputs.VERSION }}"
           base: canary
+          delete-branch: true
           title: "Bump version to ${{ steps.resolve-version.outputs.VERSION }}"
           body: |
             This PR bumps the application version to ${{ steps.resolve-version.outputs.VERSION }}.
             The change was produced automatically by the CI canary workflow.
 
       - name: Label version bump PR
-        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
+        if: github.run_attempt == 1 && steps.create_pr.outputs.pull-request-number != ''
         continue-on-error: true
         uses: actions/github-script@v6
         with:
@@ -154,7 +199,7 @@ jobs:
             }
 
       - name: Merge version bump PR (skip CI)
-        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
+        if: github.run_attempt == 1 && steps.create_pr.outputs.pull-request-number != ''
         uses: actions/github-script@v6
         env:
           PR_NUMBER: ${{ steps.create_pr.outputs['pull-request-number'] }}
@@ -172,19 +217,9 @@ jobs:
               commit_title: `[skip ci] Merge pull request ${pr} - Bump version to ${process.env.NEW_VERSION}`,
               commit_message: `[skip ci] Merge: Bump version to ${process.env.NEW_VERSION}`
             });
-            // Optionally delete the branch
-            try {
-              const prInfo = await github.rest.pulls.get({ owner: context.repo.owner, repo: context.repo.repo, pull_number: pr });
-              const branch = prInfo.data.head.ref;
-              if (branch && branch.startsWith('ci/')) {
-                await github.rest.git.deleteRef({ owner: context.repo.owner, repo: context.repo.repo, ref: `heads/${branch}` });
-              }
-            } catch (err) {
-              console.log(`Branch delete skipped or failed: ${err.message}`);
-            }
 
-      - name: Refresh workspace to merged canary version
-        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
+      - name: Refresh workspace to current canary version
+        if: github.run_attempt != 1 || steps.create_pr.outputs.pull-request-number != ''
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -233,11 +268,13 @@ jobs:
         with:
           name: canary-artifacts
           path: artifacts/*.zip
+
       - name: Show resolved version
         run: |
           echo "Resolved version: ${{ steps.resolve-version.outputs.VERSION }}"
 
       - name: Login to Docker Hub
+        if: github.run_attempt == 1
         uses: docker/login-action@v2
         with:
           registry: docker.io
@@ -245,6 +282,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
+        if: github.run_attempt == 1
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -252,6 +290,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to ATCR
+        if: github.run_attempt == 1
         uses: docker/login-action@v2
         with:
           registry: atcr.io
@@ -268,6 +307,7 @@ jobs:
           echo "ATCR_IMAGE=atcr.io/therobbiedavis.com/listenarr" >> $GITHUB_OUTPUT
 
       - name: Find triggering Pull Request
+        if: github.run_attempt == 1
         id: find_triggering_pr
         run: |
           # Find merged PRs associated with this commit, excluding version bump PRs
@@ -339,6 +379,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sanitize PR body and create release notes
+        if: github.run_attempt == 1
         id: sanitize_pr_body
         run: |
           # Sanitize PR body - remove potential malicious content, limit length
@@ -397,6 +438,7 @@ jobs:
           PR_NUMBER: ${{ steps.find_triggering_pr.outputs.PR_NUMBER }}
 
       - name: Create GitHub Pre-Release
+        if: github.run_attempt == 1
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.resolve-version.outputs.VERSION }}
@@ -408,9 +450,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
+        if: github.run_attempt == 1
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
+        if: github.run_attempt == 1
         uses: docker/setup-buildx-action@v2
 
       - name: Publish API for runtime image
@@ -458,6 +502,7 @@ jobs:
           path: listenarr.api/publish
 
       - name: Build and push API image (canary + sha)
+        if: github.run_attempt == 1
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -476,13 +521,13 @@ jobs:
 
       - name: Notify Discord
         uses: rjstone/discord-webhook-notify@v2.2.1
-        if: ${{ github.repository_owner == 'listenarrs' }}
+        if: github.run_attempt == 1 && github.repository_owner == 'listenarrs'
         with:
-            severity: info
-            description: v${{steps.resolve-version.outputs.VERSION}} - ${{ steps.find_triggering_pr.outputs.PR_TITLE }}
-            details: '${{ steps.sanitize_pr_body.outputs.SANITIZED_PR_BODY }}'
-            text: A new canary build has been released for docker.
-            webhookUrl: ${{ secrets.LISTENARR_DISCORD_WEBHOOK_URL }}
+          severity: info
+          description: v${{steps.resolve-version.outputs.VERSION}} - ${{ steps.find_triggering_pr.outputs.PR_TITLE }}
+          details: '${{ steps.sanitize_pr_body.outputs.SANITIZED_PR_BODY }}'
+          text: A new canary build has been released for docker.
+          webhookUrl: ${{ secrets.LISTENARR_DISCORD_WEBHOOK_URL }}
 
       # version bump was pushed via PR+auto-merge above
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,9 @@
 name: Nightly — build executables & Docker (develop)
 
+concurrency:
+  group: nightly-build-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write
@@ -24,6 +28,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Refresh to current develop head on rerun
+        if: github.run_attempt != 1
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: develop
+          clean: true
+
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v3
         with:
@@ -34,11 +46,12 @@ jobs:
         with:
           node-version: 20
 
-      - name: Resolve and bump version (minor)
+      - name: Resolve version
         id: resolve-version
         run: |
           set -euo pipefail
           CSProj=${{ env.API_PROJECT }}
+
           # Read <Version> from csproj, then fall back to <AssemblyVersion>
           VERSION=$(sed -n "s:.*<Version>\(.*\)</Version>.*:\1:p" "$CSProj" 2>/dev/null || true)
           if [ -z "${VERSION}" ]; then
@@ -47,19 +60,27 @@ jobs:
           if [ -z "${VERSION}" ]; then
             VERSION=$(node -p "require('./fe/package.json').version" 2>/dev/null || echo "0.0.0")
           fi
+
           echo "Found base version: ${VERSION}"
-          IFS='.' read -r MAJOR MINOR PATCH <<< "${VERSION}"
-          MINOR=${MINOR:-0}
-          NEWMINOR=$((MINOR + 1))
-          NEWVERSION="${MAJOR}.${NEWMINOR}.0"
-          echo "Bumped nightly version: ${NEWVERSION}"
-          echo "VERSION=${NEWVERSION}" >> $GITHUB_OUTPUT
+
+          if [ "${{ github.run_attempt }}" != "1" ]; then
+            RESOLVED_VERSION="${VERSION}"
+            echo "Rerun detected. Using current develop version without bump: ${RESOLVED_VERSION}"
+          else
+            IFS='.' read -r MAJOR MINOR PATCH <<< "${VERSION}"
+            MINOR=${MINOR:-0}
+            NEWMINOR=$((MINOR + 1))
+            RESOLVED_VERSION="${MAJOR}.${NEWMINOR}.0"
+            echo "Bumped nightly version: ${RESOLVED_VERSION}"
+          fi
+
+          echo "VERSION=${RESOLVED_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Restore .NET
         run: dotnet restore listenarr.slnx
 
-      - name: Persist bumped version to csproj (for build)
-        if: steps.resolve-version.outputs.VERSION != ''
+      - name: Persist bumped version to csproj (first attempt only)
+        if: github.run_attempt == 1 && steps.resolve-version.outputs.VERSION != ''
         env:
           NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
         run: |
@@ -68,10 +89,12 @@ jobs:
           cat > update_version.py <<'PY'
           import os
           import xml.etree.ElementTree as ET
+
           path = 'listenarr.api/Listenarr.Api.csproj'
           new = os.environ['NEW_VERSION']
           tree = ET.parse(path)
           root = tree.getroot()
+
           # Update Version
           found_version = False
           for elem in root.findall('.//Version'):
@@ -83,6 +106,7 @@ jobs:
               if pg is None:
                   pg = ET.SubElement(root, 'PropertyGroup')
               ET.SubElement(pg, 'Version').text = new
+
           # Update AssemblyVersion
           found_assembly = False
           for elem in root.findall('.//AssemblyVersion'):
@@ -94,32 +118,53 @@ jobs:
               if pg is None:
                   pg = ET.SubElement(root, 'PropertyGroup')
               ET.SubElement(pg, 'AssemblyVersion').text = new
+
           tree.write(path, encoding='utf-8', xml_declaration=True)
           print('Wrote new version and assembly version to csproj')
           PY
           python3 update_version.py
 
       - name: Sync frontend and package metadata to bumped version
-        if: steps.resolve-version.outputs.VERSION != ''
+        if: github.run_attempt == 1 && steps.resolve-version.outputs.VERSION != ''
         env:
           NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
         run: node scripts/sync-fe-version-from-csproj.mjs
 
+      - name: Check for tracked version changes
+        id: version_changes
+        if: github.run_attempt == 1
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- \
+            listenarr.api/Listenarr.Api.csproj \
+            package.json \
+            package-lock.json \
+            fe/package.json \
+            fe/package-lock.json; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No tracked version changes detected."
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Tracked version changes detected."
+          fi
+
       - name: Create Pull Request for version bump
         id: create_pr
+        if: github.run_attempt == 1 && steps.version_changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GH_PAT }}
           commit-message: "[skip ci] Bump version to ${{ steps.resolve-version.outputs.VERSION }}"
           branch: "ci/version-bump-${{ steps.resolve-version.outputs.VERSION }}"
           base: develop
+          delete-branch: true
           title: "Bump version to ${{ steps.resolve-version.outputs.VERSION }}"
           body: |
             This PR bumps the application version to ${{ steps.resolve-version.outputs.VERSION }}.
             The change was produced automatically by the CI nightly workflow.
 
       - name: Label version bump PR
-        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
+        if: github.run_attempt == 1 && steps.create_pr.outputs.pull-request-number != ''
         continue-on-error: true
         uses: actions/github-script@v6
         with:
@@ -154,7 +199,7 @@ jobs:
             }
 
       - name: Merge version bump PR (skip CI)
-        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
+        if: github.run_attempt == 1 && steps.create_pr.outputs.pull-request-number != ''
         uses: actions/github-script@v6
         env:
           PR_NUMBER: ${{ steps.create_pr.outputs['pull-request-number'] }}
@@ -172,19 +217,9 @@ jobs:
               commit_title: `[skip ci] Merge pull request ${pr} - Bump version to ${process.env.NEW_VERSION}`,
               commit_message: `[skip ci] Merge: Bump version to ${process.env.NEW_VERSION}`
             });
-            // Optionally delete the branch
-            try {
-              const prInfo = await github.rest.pulls.get({ owner: context.repo.owner, repo: context.repo.repo, pull_number: pr });
-              const branch = prInfo.data.head.ref;
-              if (branch && branch.startsWith('ci/')) {
-                await github.rest.git.deleteRef({ owner: context.repo.owner, repo: context.repo.repo, ref: `heads/${branch}` });
-              }
-            } catch (err) {
-              console.log(`Branch delete skipped or failed: ${err.message}`);
-            }
 
-      - name: Refresh workspace to merged develop version
-        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
+      - name: Refresh workspace to current develop version
+        if: github.run_attempt != 1 || steps.create_pr.outputs.pull-request-number != ''
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -233,6 +268,7 @@ jobs:
         with:
           name: nightly-artifacts
           path: artifacts/*.zip
+
       - name: Show resolved version
         run: |
           echo "Resolved version: ${{ steps.resolve-version.outputs.VERSION }}"
@@ -261,17 +297,13 @@ jobs:
       - name: Set image name
         id: set-tags
         run: |
-          # Use repository owner as namespace (avoids embedding secrets into names)
           echo "DOCKER_IMAGE=docker.io/therobbiedavis/listenarr" >> $GITHUB_OUTPUT
-          # Publish GHCR images under same owner namespace
           echo "GHCR_IMAGE=ghcr.io/listenarrs/listenarr" >> $GITHUB_OUTPUT
           echo "ATCR_IMAGE=atcr.io/therobbiedavis.com/listenarr" >> $GITHUB_OUTPUT
 
       - name: Find triggering Pull Request
         id: find_triggering_pr
         run: |
-          # Find merged PRs associated with this commit, excluding version bump PRs
-          # Use a simpler approach: get recent merged PRs to develop and find the right one
           PR_DATA=$(gh api graphql -f query='
             query($owner: String!, $repo: String!) {
               repository(owner: $owner, name: $repo) {
@@ -296,7 +328,6 @@ jobs:
               }
             }' -f owner='${{ github.repository_owner }}' -f repo='${{ github.event.repository.name }}')
 
-          # Filter out version bump PRs and find the first non-version-bump PR
           FILTERED_PR=$(echo "$PR_DATA" | jq -r '
             [.data.repository.pullRequests.edges[] |
             select(
@@ -307,11 +338,9 @@ jobs:
             {number, title, body, baseRefName}][0] // null
           ')
 
-          # Debug: Show what PRs we found
           echo "Recent PRs found:"
           echo "$PR_DATA" | jq -r '.data.repository.pullRequests.edges[:5][] | "PR #\(.node.number): \(.node.title)"'
 
-          # Extract PR details from the filtered result
           if [ "$FILTERED_PR" != "" ] && [ "$FILTERED_PR" != "null" ]; then
             PR_NUMBER=$(echo "$FILTERED_PR" | jq -r '.number // ""')
             PR_TITLE=$(echo "$FILTERED_PR" | jq -r '.title // ""')
@@ -331,7 +360,6 @@ jobs:
           echo "PR_TITLE=$PR_TITLE" >> $GITHUB_OUTPUT
           echo "PR_BASE_REF=$PR_BASE_REF" >> $GITHUB_OUTPUT
 
-          # Store raw PR body for sanitization
           echo "PR_BODY_RAW<<EOF_PR_BODY" >> $GITHUB_OUTPUT
           echo "$PR_BODY_RAW" >> $GITHUB_OUTPUT
           echo "EOF_PR_BODY" >> $GITHUB_OUTPUT
@@ -341,39 +369,27 @@ jobs:
       - name: Sanitize PR body and create release notes
         id: sanitize_pr_body
         run: |
-          # Sanitize PR body - remove potential malicious content, limit length
           python3 << 'PYTHON_SCRIPT'
           import os
           import re
           import html
 
-          # Get the raw PR body
           pr_body_raw = os.environ.get('PR_BODY_RAW', '')
 
-          # Basic sanitization
-          # 1. HTML escape to prevent injection
           sanitized = html.escape(pr_body_raw)
-
-          # 2. Remove script tags and other potentially dangerous content
           sanitized = re.sub(r'<script[^>]*>.*?</script>', '', sanitized, flags=re.IGNORECASE | re.DOTALL)
           sanitized = re.sub(r'<iframe[^>]*>.*?</iframe>', '', sanitized, flags=re.IGNORECASE | re.DOTALL)
           sanitized = re.sub(r'javascript:', '', sanitized, flags=re.IGNORECASE)
 
-          # 3. Limit length to prevent overly long descriptions (max 2000 chars)
           if len(sanitized) > 2000:
               sanitized = sanitized[:1997] + '...'
 
-          # 4. Clean up excessive whitespace
           sanitized = re.sub(r'\n\s*\n\s*\n', '\n\n', sanitized)
           sanitized = sanitized.strip()
 
-          # If empty after sanitization, provide a default
           if not sanitized:
               sanitized = "No description provided."
 
-          print(f"Sanitized PR body (length: {len(sanitized)} chars)")
-
-          # Create the full body for the release
           full_body = f"""{sanitized}
 
           ---
@@ -384,11 +400,9 @@ jobs:
           - Commit: {os.environ.get('GITHUB_SHA', 'unknown')}
           - Original PR: #{os.environ.get('PR_NUMBER', 'unknown')}"""
 
-          # Output the sanitized content
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
               f.write(f"SANITIZED_PR_BODY<<EOF_SANITIZED\n{sanitized}\nEOF_SANITIZED\n")
               f.write(f"FULL_RELEASE_BODY<<EOF_FULL\n{full_body}\nEOF_FULL\n")
-
           PYTHON_SCRIPT
         env:
           PR_BODY_RAW: ${{ steps.find_triggering_pr.outputs.PR_BODY_RAW }}
@@ -416,7 +430,6 @@ jobs:
       - name: Publish API for runtime image
         run: |
           dotnet publish listenarr.api/Listenarr.Api.csproj -c Release -o listenarr.api/publish
-        # Ensures Listenarr.Api.dll is at listenarr.api/publish/ for Dockerfile.runtime
 
       - name: Show publish contents (sanity check)
         run: |
@@ -474,13 +487,13 @@ jobs:
 
       - name: Notify Discord
         uses: rjstone/discord-webhook-notify@v2.2.1
-        if: ${{ github.repository_owner == 'listenarrs' }}
+        if: github.run_attempt == 1 && github.repository_owner == 'listenarrs'
         with:
-            severity: info
-            description: v${{steps.resolve-version.outputs.VERSION}} - ${{ steps.find_triggering_pr.outputs.PR_TITLE }}
-            details: '${{ steps.sanitize_pr_body.outputs.SANITIZED_PR_BODY }}'
-            text: A new nightly build has been released for docker.
-            webhookUrl: ${{ secrets.LISTENARR_DISCORD_WEBHOOK_URL }}
+          severity: info
+          description: v${{steps.resolve-version.outputs.VERSION}} - ${{ steps.find_triggering_pr.outputs.PR_TITLE }}
+          details: '${{ steps.sanitize_pr_body.outputs.SANITIZED_PR_BODY }}'
+          text: A new nightly build has been released for docker.
+          webhookUrl: ${{ secrets.LISTENARR_DISCORD_WEBHOOK_URL }}
 
       # version bump was pushed via PR+auto-merge above
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,14 +28,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Refresh to current develop head on rerun
-        if: github.run_attempt != 1
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: develop
-          clean: true
-
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v3
         with:
@@ -46,41 +38,82 @@ jobs:
         with:
           node-version: 20
 
-      - name: Resolve version
+      - name: Resolve target version
         id: resolve-version
         run: |
           set -euo pipefail
           CSProj=${{ env.API_PROJECT }}
 
-          # Read <Version> from csproj, then fall back to <AssemblyVersion>
-          VERSION=$(sed -n "s:.*<Version>\(.*\)</Version>.*:\1:p" "$CSProj" 2>/dev/null || true)
-          if [ -z "${VERSION}" ]; then
-            VERSION=$(sed -n "s:.*<AssemblyVersion>\(.*\)</AssemblyVersion>.*:\1:p" "$CSProj" 2>/dev/null || true)
+          SOURCE_VERSION=$(sed -n "s:.*<Version>\(.*\)</Version>.*:\1:p" "$CSProj" 2>/dev/null || true)
+          if [ -z "${SOURCE_VERSION}" ]; then
+            SOURCE_VERSION=$(sed -n "s:.*<AssemblyVersion>\(.*\)</AssemblyVersion>.*:\1:p" "$CSProj" 2>/dev/null || true)
           fi
-          if [ -z "${VERSION}" ]; then
-            VERSION=$(node -p "require('./fe/package.json').version" 2>/dev/null || echo "0.0.0")
-          fi
-
-          echo "Found base version: ${VERSION}"
-
-          if [ "${{ github.run_attempt }}" != "1" ]; then
-            RESOLVED_VERSION="${VERSION}"
-            echo "Rerun detected. Using current develop version without bump: ${RESOLVED_VERSION}"
-          else
-            IFS='.' read -r MAJOR MINOR PATCH <<< "${VERSION}"
-            MINOR=${MINOR:-0}
-            NEWMINOR=$((MINOR + 1))
-            RESOLVED_VERSION="${MAJOR}.${NEWMINOR}.0"
-            echo "Bumped nightly version: ${RESOLVED_VERSION}"
+          if [ -z "${SOURCE_VERSION}" ]; then
+            SOURCE_VERSION=$(node -p "require('./fe/package.json').version" 2>/dev/null || echo "0.0.0")
           fi
 
-          echo "VERSION=${RESOLVED_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Found source version from triggering commit: ${SOURCE_VERSION}"
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "${SOURCE_VERSION}"
+          MINOR=${MINOR:-0}
+          TARGET_VERSION="${MAJOR}.$((MINOR + 1)).0"
+
+          echo "Target nightly version: ${TARGET_VERSION}"
+          echo "SOURCE_VERSION=${SOURCE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "VERSION=${TARGET_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Inspect current develop version
+        id: inspect_target
+        run: |
+          set -euo pipefail
+          git fetch origin develop --depth=1
+
+          BRANCH_XML="$(git show origin/develop:${{ env.API_PROJECT }} 2>/dev/null || true)"
+          BRANCH_VERSION=$(printf '%s\n' "$BRANCH_XML" | sed -n "s:.*<Version>\(.*\)</Version>.*:\1:p" | head -n1)
+          if [ -z "${BRANCH_VERSION}" ]; then
+            BRANCH_VERSION=$(printf '%s\n' "$BRANCH_XML" | sed -n "s:.*<AssemblyVersion>\(.*\)</AssemblyVersion>.*:\1:p" | head -n1)
+          fi
+
+          echo "Current develop version: ${BRANCH_VERSION:-<unknown>}"
+          echo "BRANCH_VERSION=${BRANCH_VERSION}" >> "$GITHUB_OUTPUT"
+
+          STATE=$(python3 - "${BRANCH_VERSION}" "${{ steps.resolve-version.outputs.VERSION }}" <<'PY'
+          import sys
+
+          branch = sys.argv[1].strip()
+          target = sys.argv[2].strip()
+
+          def parse(v: str):
+              return tuple(int(x) for x in v.split("."))
+
+          if not branch:
+              print("pending")
+          else:
+              b = parse(branch)
+              t = parse(target)
+              if b == t:
+                  print("applied")
+              elif b > t:
+                  print("superseded")
+              else:
+                  print("pending")
+          PY
+          )
+
+          echo "bump_state=${STATE}" >> "$GITHUB_OUTPUT"
+          echo "Computed bump state: ${STATE}"
+
+      - name: Abort obsolete run
+        if: steps.inspect_target.outputs.bump_state == 'superseded'
+        run: |
+          echo "::error::Current develop version (${{ steps.inspect_target.outputs.BRANCH_VERSION }}) is newer than target version (${{ steps.resolve-version.outputs.VERSION }}). This run is obsolete and will not publish stale artifacts."
+          exit 1
 
       - name: Restore .NET
         run: dotnet restore listenarr.slnx
 
-      - name: Persist bumped version to csproj (first attempt only)
-        if: github.run_attempt == 1 && steps.resolve-version.outputs.VERSION != ''
+      - name: Persist bumped version to csproj
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.resolve-version.outputs.VERSION != ''
         env:
           NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
         run: |
@@ -95,7 +128,6 @@ jobs:
           tree = ET.parse(path)
           root = tree.getroot()
 
-          # Update Version
           found_version = False
           for elem in root.findall('.//Version'):
               elem.text = new
@@ -107,7 +139,6 @@ jobs:
                   pg = ET.SubElement(root, 'PropertyGroup')
               ET.SubElement(pg, 'Version').text = new
 
-          # Update AssemblyVersion
           found_assembly = False
           for elem in root.findall('.//AssemblyVersion'):
               elem.text = new
@@ -125,14 +156,14 @@ jobs:
           python3 update_version.py
 
       - name: Sync frontend and package metadata to bumped version
-        if: github.run_attempt == 1 && steps.resolve-version.outputs.VERSION != ''
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.resolve-version.outputs.VERSION != ''
         env:
           NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
         run: node scripts/sync-fe-version-from-csproj.mjs
 
       - name: Check for tracked version changes
         id: version_changes
-        if: github.run_attempt == 1
+        if: steps.inspect_target.outputs.bump_state == 'pending'
         run: |
           set -euo pipefail
           if git diff --quiet -- \
@@ -150,7 +181,7 @@ jobs:
 
       - name: Create Pull Request for version bump
         id: create_pr
-        if: github.run_attempt == 1 && steps.version_changes.outputs.has_changes == 'true'
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.version_changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GH_PAT }}
@@ -163,8 +194,14 @@ jobs:
             This PR bumps the application version to ${{ steps.resolve-version.outputs.VERSION }}.
             The change was produced automatically by the CI nightly workflow.
 
+      - name: Ensure version bump PR exists when required
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.create_pr.outputs.pull-request-number == ''
+        run: |
+          echo "::error::A nightly version bump was required, but no pull request was created or found."
+          exit 1
+
       - name: Label version bump PR
-        if: github.run_attempt == 1 && steps.create_pr.outputs.pull-request-number != ''
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.create_pr.outputs.pull-request-number != ''
         continue-on-error: true
         uses: actions/github-script@v6
         with:
@@ -199,7 +236,7 @@ jobs:
             }
 
       - name: Merge version bump PR (skip CI)
-        if: github.run_attempt == 1 && steps.create_pr.outputs.pull-request-number != ''
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.create_pr.outputs.pull-request-number != ''
         uses: actions/github-script@v6
         env:
           PR_NUMBER: ${{ steps.create_pr.outputs['pull-request-number'] }}
@@ -219,7 +256,7 @@ jobs:
             });
 
       - name: Refresh workspace to current develop version
-        if: github.run_attempt != 1 || steps.create_pr.outputs.pull-request-number != ''
+        if: steps.inspect_target.outputs.bump_state == 'applied' || steps.create_pr.outputs.pull-request-number != ''
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -227,7 +264,7 @@ jobs:
           clean: true
 
       - name: Verify synced workspace version
-        if: steps.resolve-version.outputs.VERSION != ''
+        if: steps.inspect_target.outputs.bump_state == 'applied' || steps.create_pr.outputs.pull-request-number != ''
         env:
           NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
         run: |
@@ -490,7 +527,7 @@ jobs:
         if: github.run_attempt == 1 && github.repository_owner == 'listenarrs'
         with:
           severity: info
-          description: v${{steps.resolve-version.outputs.VERSION}} - ${{ steps.find_triggering_pr.outputs.PR_TITLE }}
+          description: v${{ steps.resolve-version.outputs.VERSION }} - ${{ steps.find_triggering_pr.outputs.PR_TITLE }}
           details: '${{ steps.sanitize_pr_body.outputs.SANITIZED_PR_BODY }}'
           text: A new nightly build has been released for docker.
           webhookUrl: ${{ secrets.LISTENARR_DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release — build executables, Docker images, and create GitHub Release
 
+concurrency:
+  group: release-build-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write
@@ -24,16 +28,30 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Refresh to current main head on rerun
+        if: github.run_attempt != 1
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+          clean: true
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
 
-      - name: Resolve and bump version (major)
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Resolve version
         id: resolve-version
         run: |
           set -euo pipefail
           CSProj=${{ env.API_PROJECT }}
+
           VERSION=$(sed -n "s:.*<Version>\(.*\)</Version>.*:\1:p" "$CSProj" 2>/dev/null || true)
           if [ -z "${VERSION}" ]; then
             VERSION=$(sed -n "s:.*<AssemblyVersion>\(.*\)</AssemblyVersion>.*:\1:p" "$CSProj" 2>/dev/null || true)
@@ -41,19 +59,27 @@ jobs:
           if [ -z "${VERSION}" ]; then
             VERSION=$(node -p "require('./fe/package.json').version" 2>/dev/null || echo "0.0.0")
           fi
+
           echo "Found base version: ${VERSION}"
-          IFS='.' read -r MAJOR MINOR PATCH <<< "${VERSION}"
-          MAJOR=${MAJOR:-0}
-          NEWMAJOR=$((MAJOR + 1))
-          NEWVERSION="${NEWMAJOR}.0.0"
-          echo "Bumped release version: ${NEWVERSION}"
-          echo "VERSION=${NEWVERSION}" >> $GITHUB_OUTPUT
+
+          if [ "${{ github.run_attempt }}" != "1" ]; then
+            RESOLVED_VERSION="${VERSION}"
+            echo "Rerun detected. Using current main version without bump: ${RESOLVED_VERSION}"
+          else
+            IFS='.' read -r MAJOR MINOR PATCH <<< "${VERSION}"
+            MAJOR=${MAJOR:-0}
+            NEWMAJOR=$((MAJOR + 1))
+            RESOLVED_VERSION="${NEWMAJOR}.0.0"
+            echo "Bumped release version: ${RESOLVED_VERSION}"
+          fi
+
+          echo "VERSION=${RESOLVED_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Restore .NET
         run: dotnet restore listenarr.slnx
 
-      - name: Persist bumped version to csproj (for build)
-        if: steps.resolve-version.outputs.VERSION != ''
+      - name: Persist bumped version to csproj (first attempt only)
+        if: github.run_attempt == 1 && steps.resolve-version.outputs.VERSION != ''
         env:
           NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
         run: |
@@ -62,11 +88,12 @@ jobs:
           cat > update_version.py <<'PY'
           import os
           import xml.etree.ElementTree as ET
+
           path = 'listenarr.api/Listenarr.Api.csproj'
           new = os.environ['NEW_VERSION']
           tree = ET.parse(path)
           root = tree.getroot()
-          # Update Version
+
           found_version = False
           for elem in root.findall('.//Version'):
               elem.text = new
@@ -77,7 +104,7 @@ jobs:
               if pg is None:
                   pg = ET.SubElement(root, 'PropertyGroup')
               ET.SubElement(pg, 'Version').text = new
-          # Update AssemblyVersion
+
           found_assembly = False
           for elem in root.findall('.//AssemblyVersion'):
               elem.text = new
@@ -88,32 +115,53 @@ jobs:
               if pg is None:
                   pg = ET.SubElement(root, 'PropertyGroup')
               ET.SubElement(pg, 'AssemblyVersion').text = new
+
           tree.write(path, encoding='utf-8', xml_declaration=True)
           print('Wrote new version and assembly version to csproj')
           PY
           python3 update_version.py
 
       - name: Sync frontend and package metadata to bumped version
-        if: steps.resolve-version.outputs.VERSION != ''
+        if: github.run_attempt == 1 && steps.resolve-version.outputs.VERSION != ''
         env:
           NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
         run: node scripts/sync-fe-version-from-csproj.mjs
 
+      - name: Check for tracked version changes
+        id: version_changes
+        if: github.run_attempt == 1
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- \
+            listenarr.api/Listenarr.Api.csproj \
+            package.json \
+            package-lock.json \
+            fe/package.json \
+            fe/package-lock.json; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No tracked version changes detected."
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Tracked version changes detected."
+          fi
+
       - name: Create Pull Request for version bump (release)
         id: create_pr
+        if: github.run_attempt == 1 && steps.version_changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GH_PAT }}
           commit-message: "[skip ci] Bump version to ${{ steps.resolve-version.outputs.VERSION }}"
           branch: "ci/release-version-bump-${{ steps.resolve-version.outputs.VERSION }}"
           base: main
+          delete-branch: true
           title: "Bump version to ${{ steps.resolve-version.outputs.VERSION }}"
           body: |
             This PR bumps the application version to ${{ steps.resolve-version.outputs.VERSION }}.
             The change was produced automatically by the CI release workflow.
 
       - name: Label version bump PR
-        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
+        if: github.run_attempt == 1 && steps.create_pr.outputs.pull-request-number != ''
         continue-on-error: true
         uses: actions/github-script@v6
         with:
@@ -148,7 +196,7 @@ jobs:
             }
 
       - name: Merge release version bump PR (skip CI)
-        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
+        if: github.run_attempt == 1 && steps.create_pr.outputs.pull-request-number != ''
         uses: actions/github-script@v6
         env:
           PR_NUMBER: ${{ steps.create_pr.outputs['pull-request-number'] }}
@@ -166,18 +214,9 @@ jobs:
               commit_title: `[skip ci] Merge pull request ${pr} - Bump version to ${process.env.NEW_VERSION}`,
               commit_message: `[skip ci] Merge: Bump version to ${process.env.NEW_VERSION}`
             });
-            try {
-              const prInfo = await github.rest.pulls.get({ owner: context.repo.owner, repo: context.repo.repo, pull_number: pr });
-              const branch = prInfo.data.head.ref;
-              if (branch && branch.startsWith('ci/')) {
-                await github.rest.git.deleteRef({ owner: context.repo.owner, repo: context.repo.repo, ref: `heads/${branch}` });
-              }
-            } catch (err) {
-              console.log(`Branch delete skipped or failed: ${err.message}`);
-            }
 
-      - name: Refresh workspace to merged main version
-        if: ${{ steps.create_pr.outputs.pull-request-number != '' }}
+      - name: Refresh workspace to current main version
+        if: github.run_attempt != 1 || steps.create_pr.outputs.pull-request-number != ''
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -203,14 +242,9 @@ jobs:
       - name: Find triggering Pull Request
         id: find_triggering_pr
         run: |
-          # For release workflow, we need to find the PR that was merged to main
-          # which resulted in this tag being created, excluding version bump PRs
-
-          # First, get the tag information and find the commit it points to
           TAG_COMMIT=$(git rev-list -n 1 ${{ github.ref }})
           echo "Tag ${{ github.ref }} points to commit: $TAG_COMMIT"
 
-          # Find recent merged PRs to main, including labels for filtering
           PR_DATA=$(gh api graphql -f query='
             query($owner: String!, $repo: String!) {
               repository(owner: $owner, name: $repo) {
@@ -236,7 +270,6 @@ jobs:
               }
             }' -f owner='${{ github.repository_owner }}' -f repo='${{ github.event.repository.name }}')
 
-          # Filter out version bump PRs and find the first non-version-bump PR
           FILTERED_PR=$(echo "$PR_DATA" | jq -r '
             [.data.repository.pullRequests.edges[] |
             select(
@@ -247,11 +280,9 @@ jobs:
             {number, title, body, baseRefName}][0] // null
           ')
 
-          # Debug: Show what PRs we found
           echo "Recent PRs found:"
           echo "$PR_DATA" | jq -r '.data.repository.pullRequests.edges[:5][] | "PR #\(.node.number): \(.node.title)"'
 
-          # Extract PR details from the filtered result
           if [ "$FILTERED_PR" != "" ] && [ "$FILTERED_PR" != "null" ]; then
             PR_NUMBER=$(echo "$FILTERED_PR" | jq -r '.number // ""')
             PR_TITLE=$(echo "$FILTERED_PR" | jq -r '.title // ""')
@@ -271,7 +302,6 @@ jobs:
           echo "PR_TITLE=$PR_TITLE" >> $GITHUB_OUTPUT
           echo "PR_BASE_REF=$PR_BASE_REF" >> $GITHUB_OUTPUT
 
-          # Store raw PR body for sanitization
           echo "PR_BODY_RAW<<EOF_PR_BODY" >> $GITHUB_OUTPUT
           echo "$PR_BODY_RAW" >> $GITHUB_OUTPUT
           echo "EOF_PR_BODY" >> $GITHUB_OUTPUT
@@ -281,39 +311,27 @@ jobs:
       - name: Sanitize PR body and create release notes
         id: sanitize_pr_body
         run: |
-          # Sanitize PR body - remove potential malicious content, limit length
           python3 << 'PYTHON_SCRIPT'
           import os
           import re
           import html
 
-          # Get the raw PR body
           pr_body_raw = os.environ.get('PR_BODY_RAW', '')
 
-          # Basic sanitization
-          # 1. HTML escape to prevent injection
           sanitized = html.escape(pr_body_raw)
-
-          # 2. Remove script tags and other potentially dangerous content
           sanitized = re.sub(r'<script[^>]*>.*?</script>', '', sanitized, flags=re.IGNORECASE | re.DOTALL)
           sanitized = re.sub(r'<iframe[^>]*>.*?</iframe>', '', sanitized, flags=re.IGNORECASE | re.DOTALL)
           sanitized = re.sub(r'javascript:', '', sanitized, flags=re.IGNORECASE)
 
-          # 3. Limit length to prevent overly long descriptions (max 2000 chars)
           if len(sanitized) > 2000:
               sanitized = sanitized[:1997] + '...'
 
-          # 4. Clean up excessive whitespace
           sanitized = re.sub(r'\n\s*\n\s*\n', '\n\n', sanitized)
           sanitized = sanitized.strip()
 
-          # If empty after sanitization, provide a default
           if not sanitized:
               sanitized = "No description provided."
 
-          print(f"Sanitized PR body (length: {len(sanitized)} chars)")
-
-          # Create the full body for the release
           version = os.environ.get('VERSION', 'unknown')
           tag = os.environ.get('GITHUB_REF', '').replace('refs/tags/', '')
           full_body = f"""{sanitized}
@@ -326,11 +344,9 @@ jobs:
           - Commit: {os.environ.get('GITHUB_SHA', 'unknown')}
           - Original PR: #{os.environ.get('PR_NUMBER', 'unknown')}"""
 
-          # Output the sanitized content
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
               f.write(f"SANITIZED_PR_BODY<<EOF_SANITIZED\n{sanitized}\nEOF_SANITIZED\n")
               f.write(f"FULL_RELEASE_BODY<<EOF_FULL\n{full_body}\nEOF_FULL\n")
-
           PYTHON_SCRIPT
         env:
           PR_BODY_RAW: ${{ steps.find_triggering_pr.outputs.PR_BODY_RAW }}
@@ -341,11 +357,6 @@ jobs:
 
       - name: Build solution
         run: dotnet build listenarr.slnx -c Release --no-restore
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
 
       - name: Publish linux-x64
         run: dotnet publish ${{ env.API_PROJECT }} -c Release -r linux-x64 --self-contained true /p:PublishSingleFile=true -o ${{ env.API_OUTPUT }}/linux-x64
@@ -407,7 +418,6 @@ jobs:
       - name: Publish API for runtime image
         run: |
           dotnet publish listenarr.api/Listenarr.Api.csproj -c Release -o listenarr.api/publish
-        # Ensures Listenarr.Api.dll is at listenarr.api/publish/ for Dockerfile.runtime
 
       - name: Show publish contents (sanity check)
         run: |
@@ -468,16 +478,16 @@ jobs:
 
       - name: Notify Discord
         uses: rjstone/discord-webhook-notify@v2.2.1
-        if: ${{ github.repository_owner == 'listenarrs' }}
+        if: github.run_attempt == 1 && github.repository_owner == 'listenarrs'
         with:
-            severity: info
-            description: v${{steps.resolve-version.outputs.VERSION}} - ${{ steps.find_triggering_pr.outputs.PR_TITLE }}
-            details: '${{ steps.sanitize_pr_body.outputs.SANITIZED_PR_BODY }}'
-            text: A new stable build has been released for docker.
-            webhookUrl: ${{ secrets.LISTENARR_DISCORD_WEBHOOK_URL }}
+          severity: info
+          description: v${{steps.resolve-version.outputs.VERSION}} - ${{ steps.find_triggering_pr.outputs.PR_TITLE }}
+          details: '${{ steps.sanitize_pr_body.outputs.SANITIZED_PR_BODY }}'
+          text: A new stable build has been released for docker.
+          webhookUrl: ${{ secrets.LISTENARR_DISCORD_WEBHOOK_URL }}
 
       - name: Trigger docs rebuild
-        if: ${{ github.repository_owner == 'listenarrs' }}
+        if: github.run_attempt == 1 && github.repository_owner == 'listenarrs'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,21 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     env:
       API_PROJECT: listenarr.api/Listenarr.Api.csproj
+      FRONTEND_DIR: fe
       API_OUTPUT: listenarr.api/publish
 
     steps:
-      - name: Checkout
+      - name: Checkout tagged release
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Refresh to current main head on rerun
-        if: github.run_attempt != 1
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: main
-          clean: true
+          ref: ${{ github.sha }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
@@ -46,45 +40,88 @@ jobs:
         with:
           node-version: 20
 
-      - name: Resolve version
+      - name: Resolve release and next versions
         id: resolve-version
         run: |
           set -euo pipefail
           CSProj=${{ env.API_PROJECT }}
 
-          VERSION=$(sed -n "s:.*<Version>\(.*\)</Version>.*:\1:p" "$CSProj" 2>/dev/null || true)
-          if [ -z "${VERSION}" ]; then
-            VERSION=$(sed -n "s:.*<AssemblyVersion>\(.*\)</AssemblyVersion>.*:\1:p" "$CSProj" 2>/dev/null || true)
+          SOURCE_VERSION=$(sed -n "s:.*<Version>\(.*\)</Version>.*:\1:p" "$CSProj" 2>/dev/null || true)
+          if [ -z "${SOURCE_VERSION}" ]; then
+            SOURCE_VERSION=$(sed -n "s:.*<AssemblyVersion>\(.*\)</AssemblyVersion>.*:\1:p" "$CSProj" 2>/dev/null || true)
           fi
-          if [ -z "${VERSION}" ]; then
-            VERSION=$(node -p "require('./fe/package.json').version" 2>/dev/null || echo "0.0.0")
-          fi
-
-          echo "Found base version: ${VERSION}"
-
-          if [ "${{ github.run_attempt }}" != "1" ]; then
-            RESOLVED_VERSION="${VERSION}"
-            echo "Rerun detected. Using current main version without bump: ${RESOLVED_VERSION}"
-          else
-            IFS='.' read -r MAJOR MINOR PATCH <<< "${VERSION}"
-            MAJOR=${MAJOR:-0}
-            NEWMAJOR=$((MAJOR + 1))
-            RESOLVED_VERSION="${NEWMAJOR}.0.0"
-            echo "Bumped release version: ${RESOLVED_VERSION}"
+          if [ -z "${SOURCE_VERSION}" ]; then
+            SOURCE_VERSION=$(node -p "require('./fe/package.json').version" 2>/dev/null || echo "0.0.0")
           fi
 
-          echo "VERSION=${RESOLVED_VERSION}" >> "$GITHUB_OUTPUT"
+          TAG_NAME="${GITHUB_REF_NAME}"
+          RELEASE_VERSION="${TAG_NAME#v}"
+
+          echo "Found source version from tagged commit: ${SOURCE_VERSION}"
+          echo "Release tag version: ${RELEASE_VERSION}"
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "${RELEASE_VERSION}"
+          MAJOR=${MAJOR:-0}
+          NEXT_VERSION="$((MAJOR + 1)).0.0"
+
+          echo "Next release version target for main: ${NEXT_VERSION}"
+
+          echo "SOURCE_VERSION=${SOURCE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "VERSION=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "NEXT_VERSION=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Inspect current main version for post-release bump
+        id: inspect_target
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=1
+
+          MAIN_XML="$(git show origin/main:${{ env.API_PROJECT }} 2>/dev/null || true)"
+          MAIN_VERSION=$(printf '%s\n' "$MAIN_XML" | sed -n "s:.*<Version>\(.*\)</Version>.*:\1:p" | head -n1)
+          if [ -z "${MAIN_VERSION}" ]; then
+            MAIN_VERSION=$(printf '%s\n' "$MAIN_XML" | sed -n "s:.*<AssemblyVersion>\(.*\)</AssemblyVersion>.*:\1:p" | head -n1)
+          fi
+
+          echo "Current main version: ${MAIN_VERSION:-<unknown>}"
+          echo "MAIN_VERSION=${MAIN_VERSION}" >> "$GITHUB_OUTPUT"
+
+          STATE=$(python3 - "${MAIN_VERSION}" "${{ steps.resolve-version.outputs.NEXT_VERSION }}" <<'PY'
+          import sys
+
+          current = sys.argv[1].strip()
+          target = sys.argv[2].strip()
+
+          def parse(v: str):
+              return tuple(int(x) for x in v.split("."))
+
+          if not current:
+              print("pending")
+          else:
+              c = parse(current)
+              t = parse(target)
+              if c == t:
+                  print("applied")
+              elif c > t:
+                  print("superseded")
+              else:
+                  print("pending")
+          PY
+          )
+
+          echo "bump_state=${STATE}" >> "$GITHUB_OUTPUT"
+          echo "Computed post-release bump state: ${STATE}"
 
       - name: Restore .NET
         run: dotnet restore listenarr.slnx
 
-      - name: Persist bumped version to csproj (first attempt only)
-        if: github.run_attempt == 1 && steps.resolve-version.outputs.VERSION != ''
+      - name: Persist next version to csproj for post-release bump
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.resolve-version.outputs.NEXT_VERSION != ''
         env:
-          NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
+          NEW_VERSION: ${{ steps.resolve-version.outputs.NEXT_VERSION }}
         run: |
           set -euo pipefail
-          echo "Updating csproj to version $NEW_VERSION"
+          echo "Updating csproj to next version $NEW_VERSION"
           cat > update_version.py <<'PY'
           import os
           import xml.etree.ElementTree as ET
@@ -121,15 +158,15 @@ jobs:
           PY
           python3 update_version.py
 
-      - name: Sync frontend and package metadata to bumped version
-        if: github.run_attempt == 1 && steps.resolve-version.outputs.VERSION != ''
+      - name: Sync frontend and package metadata to next version
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.resolve-version.outputs.NEXT_VERSION != ''
         env:
-          NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
+          NEW_VERSION: ${{ steps.resolve-version.outputs.NEXT_VERSION }}
         run: node scripts/sync-fe-version-from-csproj.mjs
 
-      - name: Check for tracked version changes
+      - name: Check for tracked post-release version changes
         id: version_changes
-        if: github.run_attempt == 1
+        if: steps.inspect_target.outputs.bump_state == 'pending'
         run: |
           set -euo pipefail
           if git diff --quiet -- \
@@ -147,21 +184,27 @@ jobs:
 
       - name: Create Pull Request for version bump (release)
         id: create_pr
-        if: github.run_attempt == 1 && steps.version_changes.outputs.has_changes == 'true'
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.version_changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GH_PAT }}
-          commit-message: "[skip ci] Bump version to ${{ steps.resolve-version.outputs.VERSION }}"
-          branch: "ci/release-version-bump-${{ steps.resolve-version.outputs.VERSION }}"
+          commit-message: "[skip ci] Bump version to ${{ steps.resolve-version.outputs.NEXT_VERSION }}"
+          branch: "ci/release-version-bump-${{ steps.resolve-version.outputs.NEXT_VERSION }}"
           base: main
           delete-branch: true
-          title: "Bump version to ${{ steps.resolve-version.outputs.VERSION }}"
+          title: "Bump version to ${{ steps.resolve-version.outputs.NEXT_VERSION }}"
           body: |
-            This PR bumps the application version to ${{ steps.resolve-version.outputs.VERSION }}.
+            This PR bumps the application version to ${{ steps.resolve-version.outputs.NEXT_VERSION }}.
             The change was produced automatically by the CI release workflow.
 
+      - name: Ensure post-release bump PR exists when required
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.create_pr.outputs.pull-request-number == ''
+        run: |
+          echo "::error::A post-release version bump was required, but no pull request was created or found."
+          exit 1
+
       - name: Label version bump PR
-        if: github.run_attempt == 1 && steps.create_pr.outputs.pull-request-number != ''
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.create_pr.outputs.pull-request-number != ''
         continue-on-error: true
         uses: actions/github-script@v6
         with:
@@ -196,11 +239,11 @@ jobs:
             }
 
       - name: Merge release version bump PR (skip CI)
-        if: github.run_attempt == 1 && steps.create_pr.outputs.pull-request-number != ''
+        if: steps.inspect_target.outputs.bump_state == 'pending' && steps.create_pr.outputs.pull-request-number != ''
         uses: actions/github-script@v6
         env:
           PR_NUMBER: ${{ steps.create_pr.outputs['pull-request-number'] }}
-          NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
+          NEW_VERSION: ${{ steps.resolve-version.outputs.NEXT_VERSION }}
         with:
           github-token: ${{ secrets.GH_PAT }}
           script: |
@@ -215,29 +258,28 @@ jobs:
               commit_message: `[skip ci] Merge: Bump version to ${process.env.NEW_VERSION}`
             });
 
-      - name: Refresh workspace to current main version
-        if: github.run_attempt != 1 || steps.create_pr.outputs.pull-request-number != ''
+      - name: Restore tagged workspace for release build
+        if: steps.inspect_target.outputs.bump_state == 'pending'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: main
+          ref: ${{ github.sha }}
           clean: true
 
-      - name: Verify synced workspace version
-        if: steps.resolve-version.outputs.VERSION != ''
+      - name: Verify tagged workspace version
         env:
-          NEW_VERSION: ${{ steps.resolve-version.outputs.VERSION }}
+          RELEASE_VERSION: ${{ steps.resolve-version.outputs.RELEASE_VERSION }}
         run: |
           set -euo pipefail
           CS_VERSION=$(sed -n "s:.*<Version>\(.*\)</Version>.*:\1:p" "${{ env.API_PROJECT }}" | head -n1)
           FE_VERSION=$(node -p "require('./fe/package.json').version")
           ROOT_VERSION=$(node -p "require('./package.json').version")
-          echo "Workspace csproj version: ${CS_VERSION}"
-          echo "Workspace FE version: ${FE_VERSION}"
-          echo "Workspace root package version: ${ROOT_VERSION}"
-          [ "${CS_VERSION}" = "${NEW_VERSION}" ]
-          [ "${FE_VERSION}" = "${NEW_VERSION}" ]
-          [ "${ROOT_VERSION}" = "${NEW_VERSION}" ]
+          echo "Tagged workspace csproj version: ${CS_VERSION}"
+          echo "Tagged workspace FE version: ${FE_VERSION}"
+          echo "Tagged workspace root package version: ${ROOT_VERSION}"
+          [ "${CS_VERSION}" = "${RELEASE_VERSION}" ]
+          [ "${FE_VERSION}" = "${RELEASE_VERSION}" ]
+          [ "${ROOT_VERSION}" = "${RELEASE_VERSION}" ]
 
       - name: Find triggering Pull Request
         id: find_triggering_pr
@@ -332,7 +374,7 @@ jobs:
           if not sanitized:
               sanitized = "No description provided."
 
-          version = os.environ.get('VERSION', 'unknown')
+          release_version = os.environ.get('RELEASE_VERSION', 'unknown')
           tag = os.environ.get('GITHUB_REF', '').replace('refs/tags/', '')
           full_body = f"""{sanitized}
 
@@ -340,7 +382,7 @@ jobs:
 
           **Release {tag}**
 
-          - Version: {version}
+          - Version: {release_version}
           - Commit: {os.environ.get('GITHUB_SHA', 'unknown')}
           - Original PR: #{os.environ.get('PR_NUMBER', 'unknown')}"""
 
@@ -350,7 +392,7 @@ jobs:
           PYTHON_SCRIPT
         env:
           PR_BODY_RAW: ${{ steps.find_triggering_pr.outputs.PR_BODY_RAW }}
-          VERSION: ${{ steps.resolve-version.outputs.VERSION }}
+          RELEASE_VERSION: ${{ steps.resolve-version.outputs.RELEASE_VERSION }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_REF: ${{ github.ref }}
           PR_NUMBER: ${{ steps.find_triggering_pr.outputs.PR_NUMBER }}
@@ -404,8 +446,7 @@ jobs:
           echo "DOCKER_IMAGE=docker.io/therobbiedavis/listenarr" >> $GITHUB_OUTPUT
           echo "GHCR_IMAGE=ghcr.io/listenarrs/listenarr" >> $GITHUB_OUTPUT
           echo "ATCR_IMAGE=atcr.io/therobbiedavis.com/listenarr" >> $GITHUB_OUTPUT
-          TAG=${GITHUB_REF/refs/tags/}
-          echo "TAG=$TAG" >> $GITHUB_OUTPUT
+          echo "TAG=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
 
       - name: Upload release artifacts
         uses: softprops/action-gh-release@v1
@@ -414,6 +455,12 @@ jobs:
           files: artifacts/*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Publish API for runtime image
         run: |
@@ -468,20 +515,20 @@ jobs:
           tags: |
             ${{ steps.set-tags.outputs.DOCKER_IMAGE }}:stable
             ${{ steps.set-tags.outputs.DOCKER_IMAGE }}:latest
-            ${{ steps.set-tags.outputs.DOCKER_IMAGE }}:${{ steps.resolve-version.outputs.VERSION }}
+            ${{ steps.set-tags.outputs.DOCKER_IMAGE }}:${{ steps.resolve-version.outputs.RELEASE_VERSION }}
             ${{ steps.set-tags.outputs.GHCR_IMAGE }}:stable
             ${{ steps.set-tags.outputs.GHCR_IMAGE }}:latest
-            ${{ steps.set-tags.outputs.GHCR_IMAGE }}:${{ steps.resolve-version.outputs.VERSION }}
+            ${{ steps.set-tags.outputs.GHCR_IMAGE }}:${{ steps.resolve-version.outputs.RELEASE_VERSION }}
             ${{ steps.set-tags.outputs.ATCR_IMAGE }}:stable
             ${{ steps.set-tags.outputs.ATCR_IMAGE }}:latest
-            ${{ steps.set-tags.outputs.ATCR_IMAGE }}:${{ steps.resolve-version.outputs.VERSION }}
+            ${{ steps.set-tags.outputs.ATCR_IMAGE }}:${{ steps.resolve-version.outputs.RELEASE_VERSION }}
 
       - name: Notify Discord
         uses: rjstone/discord-webhook-notify@v2.2.1
         if: github.run_attempt == 1 && github.repository_owner == 'listenarrs'
         with:
           severity: info
-          description: v${{steps.resolve-version.outputs.VERSION}} - ${{ steps.find_triggering_pr.outputs.PR_TITLE }}
+          description: v${{ steps.resolve-version.outputs.RELEASE_VERSION }} - ${{ steps.find_triggering_pr.outputs.PR_TITLE }}
           details: '${{ steps.sanitize_pr_body.outputs.SANITIZED_PR_BODY }}'
           text: A new stable build has been released for docker.
           webhookUrl: ${{ secrets.LISTENARR_DISCORD_WEBHOOK_URL }}
@@ -494,6 +541,6 @@ jobs:
           repository: Listenarrs/listenarrs.github.io
           event-type: listenarr_release
           client-payload: >-
-            {"ref":"${{ github.ref_name }}","version":"${{ steps.resolve-version.outputs.VERSION }}"}
+            {"ref":"${{ github.ref_name }}","version":"${{ steps.resolve-version.outputs.RELEASE_VERSION }}"}
 
       # Skipped: separate Web image. The API image contains the frontend in wwwroot.

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "listenarr-fe",
-  "version": "0.2.64",
+  "version": "0.2.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "listenarr-fe",
-      "version": "0.2.64",
+      "version": "0.2.63",
       "hasInstallScript": true,
       "dependencies": {
         "@material/material-color-utilities": "^0.4.0",

--- a/fe/package.json
+++ b/fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "listenarr-fe",
-  "version": "0.2.64",
+  "version": "0.2.63",
   "private": true,
   "type": "module",
   "engines": {

--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>0.2.64</Version>
-    <AssemblyVersion>0.2.64</AssemblyVersion>
+    <Version>0.2.63</Version>
+    <AssemblyVersion>0.2.63</AssemblyVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);bin\**;bin/**;artifacts\**;artifacts/**</DefaultItemExcludes>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>

--- a/listenarr.api/Services/Search/Filters/AudiobookOnlyFilter.cs
+++ b/listenarr.api/Services/Search/Filters/AudiobookOnlyFilter.cs
@@ -18,7 +18,7 @@ public class AudiobookOnlyFilter : ISearchResultFilter
         if (result.IsEnriched && !string.IsNullOrWhiteSpace(result.MetadataSource))
         {
             var source = result.MetadataSource;
-            var trustedAudioSources = new[] { "Audible", "Audible", "Audnexus" };
+            var trustedAudioSources = new[] { "Audible", "Audnexus" };
 
             var hasExplicitAudioFromMetadata = (result.Runtime.HasValue && result.Runtime.Value > 0)
                                                || !string.IsNullOrWhiteSpace(result.Narrator);
@@ -40,7 +40,6 @@ public class AudiobookOnlyFilter : ISearchResultFilter
         var hasNarrator = !string.IsNullOrWhiteSpace(result.Narrator);
         var metadataIndicatesAudio = !string.IsNullOrWhiteSpace(result.MetadataSource) &&
                                      (result.MetadataSource.Contains("Audible", StringComparison.OrdinalIgnoreCase)
-                                      || result.MetadataSource.Contains("Audible", StringComparison.OrdinalIgnoreCase)
                                       || result.MetadataSource.Contains("Audnexus", StringComparison.OrdinalIgnoreCase)
                                       || result.MetadataSource.Contains("Amazon", StringComparison.OrdinalIgnoreCase));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "listenarr",
-  "version": "0.2.64",
+  "version": "0.2.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "listenarr",
-      "version": "0.2.64",
+      "version": "0.2.63",
       "dependencies": {
         "concurrently": "^9.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "listenarr",
-  "version": "0.2.64",
+  "version": "0.2.63",
   "private": true,
   "description": "Listenarr - Automated audiobook downloading and management",
   "scripts": {


### PR DESCRIPTION
## Summary

Re-do of #450. Big thanks to @lzinga for the original work in #424. I pulled a lot of that organize/rename foundation into this PR, then merged it with the newer metadata-editing work that had already started on this branch.

At a high level, this PR makes it much easier to clean up audiobook metadata and then use that metadata to rename and reorganize files on disk. It adds an organize preview/execute flow, expands metadata editing in both the add flow and the audiobook detail flow, supports richer naming tokens, and improves how series, narrators, publishers, and editions are handled across the app.

## Added

- An `Organize Files` preview and execute flow so existing audiobooks can be renamed and reorganized to match the current naming settings without needing to re-import them. (Closes #318)
- Bulk organize entry points from library and collection views, plus single-audiobook organize actions from the detail page.
- A user-defined `Edition` field and `{Edition}` naming token. (Closes #411)
- Additional naming tokens for `{Narrator}`, `{Subtitle}`, `{Publisher}`, `{Language}`, and `{Asin}`. (Closes #411)
- Multi-series memberships for audiobooks, including per-series numbering and a primary marker.
- Collection pages for narrator and publisher, similar to the existing genre browsing flow.
- Richer metadata editing in both the Add to Library modal and the Edit Audiobook modal.

## Changed

- The Add to Library modal now starts in a cleaner details view and switches into a dedicated metadata edit mode when needed.
- The audiobook detail page edit flow now works as a fuller metadata editor instead of a narrow settings form.
- Authors, narrators, and genres in the edit flow now behave more like tag-based metadata instead of plain text fields.
- Series editing now supports multiple memberships instead of forcing everything into a single series/number pair.
- The audiobook detail page now links authors, narrators, publishers, series, and genres into related collection views for easier browsing.
- The detail view now shows the series primary badge using the same visual style as the identifier primary badge.
- Organize/rename behavior was merged in a way that respects the current naming pipeline and newer metadata model instead of the older, smaller token set from the original PR.

## Fixed

- `basePath` is now included where it needs to be, so edit and organize flows launched from list views use the correct destination context.
- Root-folder matching no longer falls into false custom-path mode when a book lives exactly at the root folder.
- Organize operations are hardened so file and folder moves stay inside the configured output path.
- Organize endpoints now return `503` when the service is unavailable, and execution is capped consistently for safety.
- Settings for organize runs are loaded once per batch instead of repeatedly per audiobook.
- Edit modal fields now reliably hydrate current values, including description and release date.
- Language values in the edit flow are normalized more cleanly for display and save behavior.
- `{Author}` no longer falls back to narrator data when author metadata is missing.
- Narrator and publisher collection filtering now works the same way genre collections do.

## Removed

- The old assumption that an audiobook only has one series/series-number pairing in the edit flow.

Closes #424