### PR TITLE
Audiobook metadata editing and library organization

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -109,9 +109,6 @@ jobs:
           echo "::error::Current canary version (${{ steps.inspect_target.outputs.BRANCH_VERSION }}) is newer than target version (${{ steps.resolve-version.outputs.VERSION }}). This run is obsolete and will not publish stale artifacts."
           exit 1
 
-      - name: Restore .NET
-        run: dotnet restore listenarr.slnx
-
       - name: Persist bumped version to csproj
         if: steps.inspect_target.outputs.bump_state == 'pending' && steps.resolve-version.outputs.VERSION != ''
         env:
@@ -278,6 +275,9 @@ jobs:
           [ "${CS_VERSION}" = "${NEW_VERSION}" ]
           [ "${FE_VERSION}" = "${NEW_VERSION}" ]
           [ "${ROOT_VERSION}" = "${NEW_VERSION}" ]
+
+      - name: Restore .NET
+        run: dotnet restore listenarr.slnx
 
       - name: Build solution
         run: dotnet build listenarr.slnx -c Release --no-restore

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -109,9 +109,6 @@ jobs:
           echo "::error::Current develop version (${{ steps.inspect_target.outputs.BRANCH_VERSION }}) is newer than target version (${{ steps.resolve-version.outputs.VERSION }}). This run is obsolete and will not publish stale artifacts."
           exit 1
 
-      - name: Restore .NET
-        run: dotnet restore listenarr.slnx
-
       - name: Persist bumped version to csproj
         if: steps.inspect_target.outputs.bump_state == 'pending' && steps.resolve-version.outputs.VERSION != ''
         env:
@@ -278,6 +275,9 @@ jobs:
           [ "${CS_VERSION}" = "${NEW_VERSION}" ]
           [ "${FE_VERSION}" = "${NEW_VERSION}" ]
           [ "${ROOT_VERSION}" = "${NEW_VERSION}" ]
+
+      - name: Restore .NET
+        run: dotnet restore listenarr.slnx
 
       - name: Build solution
         run: dotnet build listenarr.slnx -c Release --no-restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,9 +112,6 @@ jobs:
           echo "bump_state=${STATE}" >> "$GITHUB_OUTPUT"
           echo "Computed post-release bump state: ${STATE}"
 
-      - name: Restore .NET
-        run: dotnet restore listenarr.slnx
-
       - name: Persist next version to csproj for post-release bump
         if: steps.inspect_target.outputs.bump_state == 'pending' && steps.resolve-version.outputs.NEXT_VERSION != ''
         env:
@@ -280,6 +277,9 @@ jobs:
           [ "${CS_VERSION}" = "${RELEASE_VERSION}" ]
           [ "${FE_VERSION}" = "${RELEASE_VERSION}" ]
           [ "${ROOT_VERSION}" = "${RELEASE_VERSION}" ]
+
+      - name: Restore .NET
+        run: dotnet restore listenarr.slnx
 
       - name: Find triggering Pull Request
         id: find_triggering_pr


### PR DESCRIPTION
## Summary

Re-do of #450. Big thanks to @lzinga for the original work in #424. I pulled a lot of that organize/rename foundation into this PR, then merged it with the newer metadata-editing work that had already started on this branch.

At a high level, this PR makes it much easier to clean up audiobook metadata and then use that metadata to rename and reorganize files on disk. It adds an organize preview/execute flow, expands metadata editing in both the add flow and the audiobook detail flow, supports richer naming tokens, and improves how series, narrators, publishers, and editions are handled across the app.

## Added

- An `Organize Files` preview and execute flow so existing audiobooks can be renamed and reorganized to match the current naming settings without needing to re-import them. (Closes #318)
- Bulk organize entry points from library and collection views, plus single-audiobook organize actions from the detail page.
- A user-defined `Edition` field and `{Edition}` naming token. (Closes #411)
- Additional naming tokens for `{Narrator}`, `{Subtitle}`, `{Publisher}`, `{Language}`, and `{Asin}`. (Closes #411)
- Multi-series memberships for audiobooks, including per-series numbering and a primary marker.
- Collection pages for narrator and publisher, similar to the existing genre browsing flow.
- Richer metadata editing in both the Add to Library modal and the Edit Audiobook modal.

## Changed

- The Add to Library modal now starts in a cleaner details view and switches into a dedicated metadata edit mode when needed.
- The audiobook detail page edit flow now works as a fuller metadata editor instead of a narrow settings form.
- Authors, narrators, and genres in the edit flow now behave more like tag-based metadata instead of plain text fields.
- Series editing now supports multiple memberships instead of forcing everything into a single series/number pair.
- The audiobook detail page now links authors, narrators, publishers, series, and genres into related collection views for easier browsing.
- The detail view now shows the series primary badge using the same visual style as the identifier primary badge.
- Organize/rename behavior was merged in a way that respects the current naming pipeline and newer metadata model instead of the older, smaller token set from the original PR.

## Fixed

- `basePath` is now included where it needs to be, so edit and organize flows launched from list views use the correct destination context.
- Root-folder matching no longer falls into false custom-path mode when a book lives exactly at the root folder.
- Organize operations are hardened so file and folder moves stay inside the configured output path.
- Organize endpoints now return `503` when the service is unavailable, and execution is capped consistently for safety.
- Settings for organize runs are loaded once per batch instead of repeatedly per audiobook.
- Edit modal fields now reliably hydrate current values, including description and release date.
- Language values in the edit flow are normalized more cleanly for display and save behavior.
- `{Author}` no longer falls back to narrator data when author metadata is missing.
- Narrator and publisher collection filtering now works the same way genre collections do.

## Removed

- The old assumption that an audiobook only has one series/series-number pairing in the edit flow.

Closes #424