### PR TITLE
feat: add session cookie for browser-native image authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.69] - 2026-04-04
 
 ### Added
 - **Session cookie for browser-native image authentication ([#468](https://github.com/Listenarrs/Listenarr/pull/468)):** Login now sets an HttpOnly `listenarr_session` cookie (SameSite=Strict, Secure on HTTPS) alongside the existing JSON token response. `SessionAuthenticationMiddleware` checks this cookie as a fallback after Bearer header, X-Session-Token, and SignalR query param, enabling browsers to authenticate image requests and other resource loads without JavaScript workarounds. Existing Bearer token and API key auth are unaffected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Session cookie for browser-native image authentication ([#468](https://github.com/Listenarrs/Listenarr/pull/468)):** Login now sets an HttpOnly `listenarr_session` cookie (SameSite=Strict, Secure on HTTPS) alongside the existing JSON token response. `SessionAuthenticationMiddleware` checks this cookie as a fallback after Bearer header, X-Session-Token, and SignalR query param, enabling browsers to authenticate image requests and other resource loads without JavaScript workarounds. Existing Bearer token and API key auth are unaffected.
+
+### Changed
+- **Session duration constants consolidated ([#468](https://github.com/Listenarrs/Listenarr/pull/468)):** `SessionService` now exposes `DefaultExpiration` and `RememberMeExpiration` as public static fields so cookie MaxAge stays in sync with DB session expiry.
+- **Test infrastructure cleanup ([#468](https://github.com/Listenarrs/Listenarr/pull/468)):** `TestStartupConfigService` and `ResolveApiBasePath` moved into a shared `TestHelpers.cs` to reduce duplication across test files.
+
 ## [0.2.68] - 2026-04-03
 
 ### Changed

--- a/listenarr.api/Controllers/AccountController.cs
+++ b/listenarr.api/Controllers/AccountController.cs
@@ -79,6 +79,18 @@ namespace Listenarr.Api.Controllers
             try
             {
                 var sessionToken = await _sessionService.CreateSessionAsync(req.Username, user?.IsAdmin == true, req.RememberMe);
+
+                // Set HttpOnly session cookie so browsers can authenticate resource
+                // requests (images, etc.) without JavaScript intervention.
+                Response.Cookies.Append("listenarr_session", sessionToken, new CookieOptions
+                {
+                    HttpOnly = true,
+                    Secure = HttpContext.Request.IsHttps,
+                    SameSite = SameSiteMode.Strict,
+                    Path = "/",
+                    MaxAge = req.RememberMe ? SessionService.RememberMeExpiration : SessionService.DefaultExpiration,
+                });
+
                 return Ok(new { message = "Logged in", sessionToken, authType = "session" });
             }
             catch (InvalidOperationException)
@@ -113,15 +125,27 @@ namespace Listenarr.Api.Controllers
                     await _sessionService.InvalidateSessionAsync(sessionToken);
                     _logger.LogInformation("Session invalidated for token {TokenHash}", SecurityRequestUtils.HashSecretForLog(sessionToken));
                 }
-                else if (User?.Identity?.AuthenticationType == "ApiKey" || username == "ApiKey")
+
+                // Clear the session cookie regardless of auth type
+                Response.Cookies.Delete("listenarr_session", new CookieOptions
                 {
-                    // API key authentication doesn't have a server-side session to clear
-                    // The client should stop sending the API key header
-                    _logger.LogInformation("API key authenticated user logged out (client should stop sending API key)");
-                }
-                else
+                    HttpOnly = true,
+                    Secure = HttpContext.Request.IsHttps,
+                    SameSite = SameSiteMode.Strict,
+                    Path = "/",
+                });
+
+                if (string.IsNullOrEmpty(sessionToken))
                 {
-                    _logger.LogInformation("No session token found in logout request");
+                    if (User?.Identity?.AuthenticationType == "ApiKey" || username == "ApiKey")
+                    {
+                        // API key authentication doesn't have a server-side session to clear
+                        _logger.LogInformation("API key authenticated user logged out (client should stop sending API key)");
+                    }
+                    else
+                    {
+                        _logger.LogInformation("No session token found in logout request");
+                    }
                 }
 
                 // Determine response auth type based on configuration
@@ -150,6 +174,13 @@ namespace Listenarr.Api.Controllers
             if (!string.IsNullOrEmpty(sessionHeader))
             {
                 return sessionHeader;
+            }
+
+            // Fall back to session cookie (set on login for browser resource requests)
+            var cookieToken = context.Request.Cookies["listenarr_session"];
+            if (!string.IsNullOrEmpty(cookieToken))
+            {
+                return cookieToken;
             }
 
             return null;

--- a/listenarr.api/Middleware/SessionAuthenticationMiddleware.cs
+++ b/listenarr.api/Middleware/SessionAuthenticationMiddleware.cs
@@ -110,6 +110,14 @@ namespace Listenarr.Api.Middleware
                             System.Diagnostics.Debug.WriteLine("Suppressed non-fatal exception in catch block.");
             }
 
+            // Fall back to session cookie for browser-initiated resource requests
+            // (images, stylesheets, etc.) that cannot attach custom headers.
+            var cookieToken = context.Request.Cookies["listenarr_session"];
+            if (!string.IsNullOrEmpty(cookieToken))
+            {
+                return cookieToken;
+            }
+
             return null;
         }
     }

--- a/listenarr.api/Services/SessionService.cs
+++ b/listenarr.api/Services/SessionService.cs
@@ -36,10 +36,13 @@ namespace Listenarr.Api.Services
 
     public class SessionService : ISessionService
     {
+        /// <summary>Default session duration (no "remember me").</summary>
+        public static readonly TimeSpan DefaultExpiration = TimeSpan.FromHours(8);
+        /// <summary>Extended session duration when "remember me" is checked.</summary>
+        public static readonly TimeSpan RememberMeExpiration = TimeSpan.FromDays(30);
+
         private readonly IDbContextFactory<ListenArrDbContext> _dbContextFactory;
         private readonly ILogger<SessionService> _logger;
-        private readonly TimeSpan _defaultExpiration = TimeSpan.FromHours(8);
-        private readonly TimeSpan _rememberMeExpiration = TimeSpan.FromDays(30);
 
         public SessionService(IDbContextFactory<ListenArrDbContext> dbContextFactory, ILogger<SessionService> logger)
         {
@@ -49,7 +52,7 @@ namespace Listenarr.Api.Services
 
         public async Task<string> CreateSessionAsync(string username, bool isAdmin, bool rememberMe = false)
         {
-            var expiration = rememberMe ? _rememberMeExpiration : _defaultExpiration;
+            var expiration = rememberMe ? RememberMeExpiration : DefaultExpiration;
             var now = DateTime.UtcNow;
 
             // Retry token generation on the unlikely chance of a hash collision.

--- a/tests/Listenarr.Api.Tests/AuthenticationMiddlewareTests.cs
+++ b/tests/Listenarr.Api.Tests/AuthenticationMiddlewareTests.cs
@@ -110,13 +110,4 @@ namespace Listenarr.Api.Tests
             return string.IsNullOrWhiteSpace(groupName) ? "/api/v1" : $"/api/{groupName}";
         }
     }
-
-    internal class TestStartupConfigService : Listenarr.Api.Services.IStartupConfigService
-    {
-        private readonly StartupConfig _cfg;
-        public TestStartupConfigService(StartupConfig cfg) { _cfg = cfg; }
-        public StartupConfig? GetConfig() => _cfg;
-        public Task ReloadAsync() => Task.CompletedTask;
-        public Task SaveAsync(StartupConfig config) => Task.CompletedTask;
-    }
 }

--- a/tests/Listenarr.Api.Tests/SessionCookieAuthTests.cs
+++ b/tests/Listenarr.Api.Tests/SessionCookieAuthTests.cs
@@ -1,0 +1,208 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Listenarr.Api.Services;
+using Listenarr.Domain.Models;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Listenarr.Api.Tests
+{
+    public class SessionCookieAuthTests : IClassFixture<ListenarrWebApplicationFactory>
+    {
+        private readonly ListenarrWebApplicationFactory _factory;
+
+        public SessionCookieAuthTests(ListenarrWebApplicationFactory factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task CookieAuth_ProtectedEndpoint_Succeeds_WithValidCookie()
+        {
+            using var factory = CreateAuthEnabledFactory();
+            var apiBase = TestHelpers.ResolveApiBasePath(factory.Services);
+
+            // Create a session directly via the service (bypasses login controller)
+            string sessionToken;
+            using (var scope = factory.Services.CreateScope())
+            {
+                var sessionService = scope.ServiceProvider.GetRequiredService<ISessionService>();
+                sessionToken = await sessionService.CreateSessionAsync("testuser", true, false);
+            }
+
+            using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,
+                HandleCookies = false,
+            });
+
+            // Send request with session token as cookie (no Bearer header)
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"{apiBase}/library");
+            request.Headers.Add("Cookie", $"listenarr_session={sessionToken}");
+            var resp = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task CookieAuth_ProtectedEndpoint_Returns401_WithInvalidCookie()
+        {
+            using var factory = CreateAuthEnabledFactory();
+            var apiBase = TestHelpers.ResolveApiBasePath(factory.Services);
+
+            using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,
+                HandleCookies = false,
+            });
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"{apiBase}/library");
+            request.Headers.Add("Cookie", "listenarr_session=invalid-garbage-token");
+            var resp = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task CookieAuth_InvalidatedSession_Returns401()
+        {
+            using var factory = CreateAuthEnabledFactory();
+            var apiBase = TestHelpers.ResolveApiBasePath(factory.Services);
+
+            // Create and then invalidate a session
+            string sessionToken;
+            using (var scope = factory.Services.CreateScope())
+            {
+                var sessionService = scope.ServiceProvider.GetRequiredService<ISessionService>();
+                sessionToken = await sessionService.CreateSessionAsync("testuser", true, false);
+                await sessionService.InvalidateSessionAsync(sessionToken);
+            }
+
+            using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,
+                HandleCookies = false,
+            });
+
+            // Cookie with invalidated token should return 401
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"{apiBase}/library");
+            request.Headers.Add("Cookie", $"listenarr_session={sessionToken}");
+            var resp = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task CookieAuth_BearerTakesPriority_OverCookie()
+        {
+            using var factory = CreateAuthEnabledFactory();
+            var apiBase = TestHelpers.ResolveApiBasePath(factory.Services);
+
+            // Create two sessions: one valid (for Bearer), one invalidated (for cookie)
+            string validToken;
+            string invalidatedToken;
+            using (var scope = factory.Services.CreateScope())
+            {
+                var sessionService = scope.ServiceProvider.GetRequiredService<ISessionService>();
+                validToken = await sessionService.CreateSessionAsync("testuser", true, false);
+                invalidatedToken = await sessionService.CreateSessionAsync("testuser", true, false);
+                await sessionService.InvalidateSessionAsync(invalidatedToken);
+            }
+
+            using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,
+                HandleCookies = false,
+            });
+
+            // Valid Bearer + invalidated cookie → should succeed (Bearer wins)
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"{apiBase}/library");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", validToken);
+            request.Headers.Add("Cookie", $"listenarr_session={invalidatedToken}");
+            var resp = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task CookieAuth_NoCookieOrBearer_Returns401()
+        {
+            using var factory = CreateAuthEnabledFactory();
+            var apiBase = TestHelpers.ResolveApiBasePath(factory.Services);
+
+            using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,
+                HandleCookies = false,
+            });
+
+            var resp = await client.GetAsync($"{apiBase}/library");
+            Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task ApiKeyHeader_AuthenticatesSuccessfully()
+        {
+            var apiKey = "test-api-key-12345";
+            using var factory = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureServices(services =>
+                {
+                    services.AddSingleton<IStartupConfigService>(sp =>
+                    {
+                        return new TestStartupConfigService(new StartupConfig
+                        {
+                            AuthenticationRequired = "true",
+                            ApiKey = apiKey,
+                        });
+                    });
+                });
+            });
+            var apiBase = TestHelpers.ResolveApiBasePath(factory.Services);
+
+            using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,
+                HandleCookies = false,
+            });
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"{apiBase}/library");
+            request.Headers.Add("X-Api-Key", apiKey);
+            var resp = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task AuthDisabled_EndpointAccessible_WithoutCredentials()
+        {
+            // Base factory already sets AuthenticationRequired = "false"
+            var apiBase = TestHelpers.ResolveApiBasePath(_factory.Services);
+
+            using var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,
+                HandleCookies = false,
+            });
+
+            // No Bearer, no cookie, no API key — should still succeed when auth is disabled
+            var resp = await client.GetAsync($"{apiBase}/library");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+
+        private WebApplicationFactory<Program> CreateAuthEnabledFactory()
+        {
+            return _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureServices(services =>
+                {
+                    services.AddSingleton<IStartupConfigService>(sp =>
+                    {
+                        return new TestStartupConfigService(new StartupConfig { AuthenticationRequired = "true" });
+                    });
+                });
+            });
+        }
+    }
+}

--- a/tests/Listenarr.Api.Tests/TestHelpers.cs
+++ b/tests/Listenarr.Api.Tests/TestHelpers.cs
@@ -1,0 +1,35 @@
+using Asp.Versioning.ApiExplorer;
+using Listenarr.Api.Services;
+using Listenarr.Domain.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Listenarr.Api.Tests
+{
+    internal static class TestHelpers
+    {
+        /// <summary>
+        /// Resolves the versioned API base path (e.g. "/api/v1") from the test server's service provider.
+        /// </summary>
+        public static string ResolveApiBasePath(IServiceProvider services)
+        {
+            using var scope = services.CreateScope();
+            var provider = scope.ServiceProvider.GetService<IApiVersionDescriptionProvider>();
+            var groupName = provider?.ApiVersionDescriptions.FirstOrDefault(d => !d.IsDeprecated)?.GroupName
+                ?? provider?.ApiVersionDescriptions.FirstOrDefault()?.GroupName;
+
+            return string.IsNullOrWhiteSpace(groupName) ? "/api/v1" : $"/api/{groupName}";
+        }
+    }
+
+    /// <summary>
+    /// Simple IStartupConfigService stub for integration tests.
+    /// </summary>
+    internal class TestStartupConfigService : IStartupConfigService
+    {
+        private readonly StartupConfig _cfg;
+        public TestStartupConfigService(StartupConfig cfg) { _cfg = cfg; }
+        public StartupConfig? GetConfig() => _cfg;
+        public Task ReloadAsync() => Task.CompletedTask;
+        public Task SaveAsync(StartupConfig config) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary

Adds an HttpOnly session cookie on login so browsers can authenticate image requests and resource loads without JavaScript workarounds.

## Problem

When auth is enabled, `<img src="/api/v1/images/...">` can't attach an `Authorization` header since browsers don't support custom headers on resource loads. The frontend works around this with a composable that fetches each image via JS, converts it to a blob URL, manages cache maps per component, and revokes blob URLs on unmount. It works but it adds a lot of complexity and a visible placeholder flash on every image.

### Added
- Session cookie (`listenarr_session`) set on login for browser-native image authentication (HttpOnly, SameSite=Strict, Secure on HTTPS)
- Cookie fallback in `SessionAuthenticationMiddleware` after Bearer, X-Session-Token, and SignalR query param
- Cookie deletion and token extraction from cookie on logout
- 7 integration tests for cookie auth, revocation, Bearer priority, API key regression, and auth-disabled mode
- Shared `TestHelpers.cs` for common test utilities

### Changed
- Session duration constants in `SessionService` consolidated as public static fields so cookie expiry stays in sync with DB session expiry
- `TestStartupConfigService` moved from `AuthenticationMiddlewareTests.cs` into shared `TestHelpers.cs`

Existing Bearer token and API key auth are completely unaffected. The cookie is only used when no header is present.

## Security

- HttpOnly, SameSite=Strict, Secure on HTTPS
- Same opaque token and DB hash validation as Bearer
- Server-side revocation works instantly
- Image endpoints are GET-only, no CSRF risk

## Tests

7 new integration tests covering cookie auth, invalid/revoked tokens, Bearer priority, API key regression, and auth-disabled mode. 602 total tests pass.

## Next Steps

With this in place a follow-up PR can simplify the frontend by replacing the blob URL fetching in `useProtectedImages` with direct image URLs since the browser now handles auth automatically via the cookie.