### PR TITLE
Fix: inputMode leftovers + revert version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,8 +142,9 @@ This project follows a layered pattern: domain models in `listenarr.domain`, EF 
   - Use the test-host patching approach to keep tests hermetic (no external network or process calls).
 
 **Testing:**
-- Run backend tests: `cd listenarr.api && dotnet test`
+- Run backend tests: `dotnet test`
 - Run frontend tests: `cd fe && npm run test:unit`
+- Run frontend type checks: `cd fe && npm run type-check`
 - Ensure all tests pass before submitting PR
 
 ### Pull Request Guidelines

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "listenarr-fe",
-  "version": "0.2.71",
+  "version": "0.2.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "listenarr-fe",
-      "version": "0.2.71",
+      "version": "0.2.70",
       "hasInstallScript": true,
       "dependencies": {
         "@material/material-color-utilities": "^0.4.0",

--- a/fe/package.json
+++ b/fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "listenarr-fe",
-  "version": "0.2.71",
+  "version": "0.2.70",
   "private": true,
   "type": "module",
   "engines": {

--- a/fe/src/components/feedback/ManualImportModal.vue
+++ b/fe/src/components/feedback/ManualImportModal.vue
@@ -125,7 +125,7 @@
             <option v-for="(field, _) in importFields.filter((field: ImportField) => field.editable)" :value="field.key">{{ field.label }}</option>
           </select>
 
-          <select v-if="showPreview" class="extra-select" v-model="inputMode">
+          <select v-if="showPreview" class="extra-select" v-model="action">
             <option value="">Select Import Mode</option>
             <option value="move">Move</option>
             <option value="hardlink/copy">Hardlink/Copy</option>
@@ -299,7 +299,7 @@ const selectedPath = ref(props.initialPath || '')
 const loading = ref(false)
 const browserMode = ref(false)
 const inputField = ref<string>('')
-const inputMode = ref<'move' | 'hardlink/copy' | ''>('')
+const action = ref<'move' | 'hardlink/copy' | ''>('')
 
 const showPreview = ref(false)
 interface PreviewItem {
@@ -624,8 +624,8 @@ const startAutomaticImport = async () => {
   try {
     // When running automatic import, send minimal request; backend will handle scanning
     const autoPayload: ManualImportRequest = { path: selectedPath.value, mode: 'automatic' }
-    if (inputMode.value === 'move' || inputMode.value === 'hardlink/copy')
-      autoPayload.inputMode = inputMode.value
+    if (action.value !== '')
+      autoPayload.action = action.value
     const resp = await apiService.startManualImport(autoPayload)
     // resp should contain import summary
     emit('imported', { imported: resp.importedCount ?? 0 })
@@ -667,7 +667,7 @@ const importSelected = async () => {
       path: selectedPath.value,
       mode: 'interactive',
       items: payloadItems,
-      inputMode: inputMode.value || 'hardlink/copy',
+      action: action.value || 'hardlink/copy',
     }
     const resp = await apiService.startManualImport(manualPayload)
     emit('imported', { imported: resp.importedCount ?? selected.length })

--- a/fe/src/components/feedback/UnmatchedFilesModal.vue
+++ b/fe/src/components/feedback/UnmatchedFilesModal.vue
@@ -358,7 +358,7 @@ async function onAdded(audiobook: Audiobook) {
     await apiService.startManualImport({
       path: item.bookFolder,
       mode: 'interactive',
-      inputMode: fileInputMode.value,
+      action: fileInputMode.value,
       items: [
         {
           fullPath: item.fullPath,
@@ -453,7 +453,7 @@ async function addAllWithAsin() {
         const importResult = await apiService.startManualImport({
           path: item.bookFolder,
           mode: 'interactive',
-          inputMode: fileInputMode.value,
+          action: fileInputMode.value,
           items: [{ fullPath: item.fullPath, matchedAudiobookId: audiobook.id }],
         })
         if (importResult && importResult.importedCount === 0) {

--- a/fe/src/components/settings/RootFolderFormModal.vue
+++ b/fe/src/components/settings/RootFolderFormModal.vue
@@ -142,7 +142,7 @@ async function confirmChange(moveFiles: boolean) {
       'Success',
       moveFiles ? 'Root renamed and move jobs queued' : 'Root renamed (files unchanged)',
     )
-    emit('saved')
+    emit('saved', root!)
   } catch (e: unknown) {
     const error = e as Error
     toast.error('Error', error?.message || 'Failed to save root folder')

--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>0.2.71</Version>
-    <AssemblyVersion>0.2.71</AssemblyVersion>
+    <Version>0.2.70</Version>
+    <AssemblyVersion>0.2.70</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefaultItemExcludes>$(DefaultItemExcludes);bin\**;bin/**;artifacts\**;artifacts/**</DefaultItemExcludes>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "listenarr",
-  "version": "0.2.71",
+  "version": "0.2.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "listenarr",
-      "version": "0.2.71",
+      "version": "0.2.70",
       "dependencies": {
         "concurrently": "^9.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "listenarr",
-  "version": "0.2.71",
+  "version": "0.2.70",
   "private": true,
   "description": "Listenarr - Automated audiobook downloading and management",
   "scripts": {


### PR DESCRIPTION
## Summary
* Fix #494, do over of #503 

### Added
* Ability to add root folders while selecting the root folder from which we want to import files
* Ability to leave files in place when importing library
* Ability to set the desired monitoring for audiobooks added through library importation

### Changed
- Added new check to do in CONTRIBUTING.md

### Fixed
- Forgot to adapt some inputMode usage to action

## Testing
* Check that the import does not change anything in the files when it is not asked to modify them

## Notes

### Next steps
* #504 : It should be possible to process the imported files to rename them using the pattern defined in the settings. Some tests for that should be added too (see InteractiveManualImport_DontMoveAnything_DontRenameAnything)
