### PR TITLE
Fix local docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,12 @@ EXPOSE 4545
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
+COPY ["Directory.Build.props", "./"]
+COPY ["Directory.Packages.props", "./"]
 COPY ["listenarr.api/Listenarr.Api.csproj", "listenarr.api/"]
+COPY ["listenarr.domain/Listenarr.Domain.csproj", "listenarr.domain/"]
+COPY ["listenarr.application/Listenarr.Application.csproj", "listenarr.application/"]
+COPY ["listenarr.infrastructure/Listenarr.Infrastructure.csproj", "listenarr.infrastructure/"]
 RUN dotnet restore "listenarr.api/Listenarr.Api.csproj"
 COPY . .
 WORKDIR "/src/listenarr.api"


### PR DESCRIPTION
## Summary

Fixes #556 

## Changes

### Fixed
The Dockerfile only copied Listenarr.Api.csproj before running dotnet restore. Since the project adopted Directory.Build.props for shared properties and Directory.Packages.props for central package management, restore failed with NETSDK1013 (empty TargetFramework) and NU1015 (missing package versions).

`docker build .` now succeeds.