### PR TITLE
Bump version to 0.2.74

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "listenarr-fe",
-  "version": "0.2.73",
+  "version": "0.2.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "listenarr-fe",
-      "version": "0.2.73",
+      "version": "0.2.74",
       "hasInstallScript": true,
       "dependencies": {
         "@material/material-color-utilities": "^0.4.0",

--- a/fe/package.json
+++ b/fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "listenarr-fe",
-  "version": "0.2.73",
+  "version": "0.2.74",
   "private": true,
   "type": "module",
   "engines": {

--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>0.2.73</Version>
-    <AssemblyVersion>0.2.73</AssemblyVersion>
+    <Version>0.2.74</Version>
+    <AssemblyVersion>0.2.74</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefaultItemExcludes>$(DefaultItemExcludes);bin\**;bin/**;artifacts\**;artifacts/**</DefaultItemExcludes>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "listenarr",
-  "version": "0.2.73",
+  "version": "0.2.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "listenarr",
-      "version": "0.2.73",
+      "version": "0.2.74",
       "dependencies": {
         "concurrently": "^9.2.1",
         "wait-on": "^9.0.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "listenarr",
-  "version": "0.2.73",
+  "version": "0.2.74",
   "private": true,
   "description": "Listenarr - Automated audiobook downloading and management",
   "scripts": {


### PR DESCRIPTION
This PR bumps the application version to 0.2.74.
The change was produced automatically by the CI canary workflow.