### PR TITLE
fix(library): make AutoSearch flag actually trigger a search on add

### DIFF
--- a/fe/src/components/domain/audiobook/AddLibraryModal.vue
+++ b/fe/src/components/domain/audiobook/AddLibraryModal.vue
@@ -501,7 +501,7 @@ const qualityProfiles = ref<QualityProfile[]>([])
 const options = ref({
   monitored: true,
   qualityProfileId: null as number | null,
-  autoSearch: false,
+  autoSearch: true,
   // editable relative path portion (relative to rootPath)
   relativePath: '' as string | null,
 })

--- a/fe/src/services/api.ts
+++ b/fe/src/services/api.ts
@@ -1150,7 +1150,7 @@ class ApiService {
       metadata: normalizedMetadata,
       monitored: options?.monitored ?? true,
       qualityProfileId: options?.qualityProfileId,
-      autoSearch: options?.autoSearch ?? false,
+      autoSearch: options?.autoSearch ?? true,
       searchResult: normalizedSearchResult,
       destinationPath: options?.destinationPath,
     }

--- a/listenarr.api/Controllers/LibraryController.cs
+++ b/listenarr.api/Controllers/LibraryController.cs
@@ -4490,7 +4490,7 @@ namespace Listenarr.Api.Controllers
             public AudibleBookMetadata Metadata { get; set; } = new();
             public bool Monitored { get; set; } = true;
             public int? QualityProfileId { get; set; }
-            public bool AutoSearch { get; set; } = false;
+            public bool AutoSearch { get; set; } = true;
             // Optional destination override for placing the audiobook base directory
             public string? DestinationPath { get; set; }
             public SearchResult? SearchResult { get; set; }

--- a/listenarr.api/Services/LibraryAddService.cs
+++ b/listenarr.api/Services/LibraryAddService.cs
@@ -18,6 +18,7 @@
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.Extensions.DependencyInjection;
 using Listenarr.Application.Repositories;
 using Listenarr.Domain.Models;
 using Listenarr.Domain.Utils;
@@ -34,6 +35,7 @@ namespace Listenarr.Api.Services
         private readonly AudibleService _audibleService;
         private readonly IConfigurationService _configurationService;
         private readonly INotificationService? _notificationService;
+        private readonly IServiceScopeFactory? _scopeFactory;
 
         public LibraryAddService(
             IAudiobookRepository repo,
@@ -43,7 +45,8 @@ namespace Listenarr.Api.Services
             IQualityProfileService qualityProfileService,
             AudibleService audibleService,
             IConfigurationService configurationService,
-            INotificationService? notificationService = null)
+            INotificationService? notificationService = null,
+            IServiceScopeFactory? scopeFactory = null)
         {
             _repo = repo;
             _historyRepository = historyRepository;
@@ -53,6 +56,7 @@ namespace Listenarr.Api.Services
             _audibleService = audibleService;
             _configurationService = configurationService;
             _notificationService = notificationService;
+            _scopeFactory = scopeFactory;
         }
 
         public async Task<LibraryAddOperationResult> AddToLibraryAsync(
@@ -196,6 +200,32 @@ namespace Listenarr.Api.Services
                 request.Monitored,
                 audiobook.QualityProfileId,
                 request.AutoSearch);
+
+            if (request.AutoSearch && audiobook.Id > 0 && _scopeFactory != null)
+            {
+                var audiobookId = audiobook.Id;
+                var audiobookTitle = audiobook.Title;
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        using var scope = _scopeFactory.CreateScope();
+                        var downloadService = scope.ServiceProvider.GetService<IDownloadService>();
+                        if (downloadService == null)
+                        {
+                            _logger.LogWarning("Auto-search requested for '{Title}' (id={Id}) but IDownloadService is not registered", audiobookTitle, audiobookId);
+                            return;
+                        }
+                        _logger.LogInformation("Auto-search firing for '{Title}' (id={Id})", audiobookTitle, audiobookId);
+                        var result = await downloadService.SearchAndDownloadAsync(audiobookId);
+                        _logger.LogInformation("Auto-search result for '{Title}' (id={Id}): success={Success}, msg={Message}", audiobookTitle, audiobookId, result?.Success, result?.Message);
+                    }
+                    catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException)
+                    {
+                        _logger.LogError(ex, "Auto-search failed for '{Title}' (id={Id})", audiobookTitle, audiobookId);
+                    }
+                });
+            }
 
             return new LibraryAddOperationResult
             {


### PR DESCRIPTION
## Summary

The `AddToLibraryRequest.AutoSearch` flag was a dead path: it was logged but no code branch ever consumed it. UI-added books were marked `Monitored=true` but no search ever fired — they sat in the library until the periodic `AutomaticSearchService` background sweep (default 6h interval) eventually picked them up.

This PR makes the flag actually do what its name says.

## Two commits

### 1. `fix(library): default AutoSearch=true on add-to-library API` (bc52104)

`AddToLibraryRequest.AutoSearch` defaulted to `false`. Whether a UI-added book got searched immediately depended on the FE remembering to pass `autoSearch: true` in every request body. From a user's perspective, "I added the book" implies "I want it" — auto-searching matches that expectation. Flips the DTO default.

The other three call sites that pass `AutoSearch=false` are intentionally left as-is — bulk paths shouldn't trigger search storms:
- `AuthorMonitoringService:265` (bulk-add monitored author catalog)
- `SeriesMonitoringService:264` (bulk-add monitored series catalog)
- `ImportListSyncService:506` (Goodreads / reading-list import)

### 2. `fix(library): wire AutoSearch flag through to actual search-and-download` (a7da950)

Even after #1, nothing acted on the flag. Search across the codebase:

```
$ grep -rIn 'request\.AutoSearch\|operation\.AutoSearch' --include='*.cs' .
listenarr.api/Services/LibraryAddService.cs:198: ... request.AutoSearch);
listenarr.api/Controllers/LibraryController.cs:208: AutoSearch = request.AutoSearch,
listenarr.api/Controllers/LibraryController.cs:601: ... request.AutoSearch);
```

All three are log statements or pass-through assignments — no `if (request.AutoSearch) { ... }` anywhere.

This commit injects `IServiceScopeFactory` (optional, so existing constructor callers / test fixtures keep working) and, when `request.AutoSearch && audiobook.Id > 0`, fires `IDownloadService.SearchAndDownloadAsync(audiobook.Id)` on a fire-and-forget background task with try/catch logging. Off the request thread so the add response stays snappy; new log lines:

```
INFO  Auto-search firing for '{Title}' (id={Id})
INFO  Auto-search result for '{Title}' (id={Id}): success={Success}, msg={Message}
ERROR Auto-search failed for '{Title}' (id={Id})   (only on exception)
```

Uses `CreateScope()` so scoped services (repos, etc.) resolve cleanly outside the request scope. `IServiceScopeFactory` was chosen over direct `IDownloadService` injection to keep the dependency cycle clear (`LibraryAddService` is itself scoped and `IDownloadService` is heavy with scoped deps).

## Test plan

- [x] Verified in production: added a book in the UI → `Auto-search firing for ...` log line within 1 second → SAB queued the download → import → `Imported | AutoImport` history → ABS picked it up via webhook
- [ ] Suggested unit test (not included; can add in a follow-up if maintainers want): assert `IDownloadService.SearchAndDownloadAsync` is called when `AutoSearch=true` and not when `AutoSearch=false`

## Notes

- No public API changes (DTO default flip is wire-compatible — callers passing `autoSearch: false` keep getting that behavior)
- No DB schema changes
- Fire-and-forget background task swallows exceptions to logs; the user-facing add response is unaffected by search/indexer failures